### PR TITLE
Encapsulate attrs in struct definition

### DIFF
--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -139,7 +139,7 @@ test "writeUpdateBody()" {
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
         }, 
-        PathAttributes{.allocator = testing.allocator, .origin = .EGP, .asPath = asPath , .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null},
+        PathAttributes{.allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null},
     );
     defer msg.deinit();
 

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -139,7 +139,7 @@ test "writeUpdateBody()" {
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
         }, 
-        PathAttributes{.allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null},
+        PathAttributes{.allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null},
     );
     defer msg.deinit();
 

--- a/src/messaging/model.zig
+++ b/src/messaging/model.zig
@@ -305,29 +305,38 @@ pub const PathAttributes = struct {
 
         if (self.atomicAggregate) |at1| {
             if (other.atomicAggregate) |at2| {
-                return at1.value == at2.value;
+                if (at1.value != at2.value) {
+                    return false;
+                }
             }
-            return false;
         } else {
-            return other.atomicAggregate != null;
+            if (other.atomicAggregate != null) {
+                return false;
+            }
         }
 
         if (self.multiExitDiscriminator) |med1| {
             if (other.multiExitDiscriminator) |med2| {
-                return med1.value == med2.value;
+                if(med1.value != med2.value) {
+                    return false;
+                }
             }
-            return false;
         } else {
-            return other.multiExitDiscriminator != null;
+            if(other.multiExitDiscriminator != null) {
+                return false;
+            }
         }
 
         if (self.aggregator) |agg| {
             if (other.aggregator) |otherAgg| {
-                return agg.value.equal(otherAgg.value);
+                if (!agg.value.equal(otherAgg.value)) {
+                    return false;
+                }
             }
-            return false;
         } else {
-            return other.aggregator != null;
+            if (other.aggregator != null) {
+                return false;
+            }
         }
 
         return true;

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -83,7 +83,7 @@ fn readAttributes(self: Self, attributesLength: u16) !PathAttributes {
         return UpdateParsingError.AttributesLengthInconsistent;
     }
 
-    return PathAttributes{.allocator = self.allocator, .origin = .EGP, .asPath = .{.allocator = self.allocator, .segments = &[_]model.ASPathSegment{}}, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null};
+    return PathAttributes{.allocator = self.allocator, .origin = .init(.EGP), .asPath = .init(.{.allocator = self.allocator, .segments = &[_]model.ASPathSegment{}}), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null};
 }
 
 pub fn readUpdateMessage(self: Self, messageLength: u16) !model.UpdateMessage {

--- a/src/rib/adj_rib.zig
+++ b/src/rib/adj_rib.zig
@@ -62,7 +62,7 @@ test "Add Route" {
 
     const route: Route = .default;
 
-    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = .createEmpty(testing.allocator), .nexthop = ip.IpV4Address.init(127, 0, 0, 1), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null });
+    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(testing.allocator)), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
 
     const path = adjRib.prefixes.getPtr(route) orelse return error.RouteNotPresent;
 
@@ -98,9 +98,9 @@ test "Set Route" {
     };
     defer asPath.deinit();
 
-    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(127, 0, 0, 1), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null });
-    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(127, 0, 0, 2), .localPref = 200, .atomicAggregate = true, .multiExitDiscriminator = 69420, .aggregator = null });
-    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(127, 0, 0, 3), .localPref = 142, .atomicAggregate = true, .multiExitDiscriminator = null, .aggregator = null });
+    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null });
+    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 2)), .localPref = .init(200), .atomicAggregate = .init(true), .multiExitDiscriminator = .init(69420), .aggregator = null });
+    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 3)), .localPref = .init(142), .atomicAggregate = .init(true), .multiExitDiscriminator = null, .aggregator = null });
 
     const path = adjRib.prefixes.getPtr(route) orelse return error.RouteNotPresent;
 
@@ -123,7 +123,7 @@ test "Remove Path" {
 
     const route: Route = .default;
 
-    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = .createEmpty(testing.allocator), .nexthop = ip.IpV4Address.init(127, 0, 0, 1), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null });
+    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(testing.allocator)), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
     adjRib.removePath(route);
 
     try testing.expectEqual(null, adjRib.prefixes.getPtr(route));

--- a/src/rib/adj_rib.zig
+++ b/src/rib/adj_rib.zig
@@ -62,19 +62,19 @@ test "Add Route" {
 
     const route: Route = .default;
 
-    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(testing.allocator)), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
+    try adjRib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(testing.allocator)), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null });
 
     const path = adjRib.prefixes.getPtr(route) orelse return error.RouteNotPresent;
 
     const attrs: PathAttributes = path.attrs;
 
-    try testing.expectEqual(model.Origin.EGP, attrs.origin);
-    try testing.expectEqualSlices(model.ASPathSegment, &[_]model.ASPathSegment{}, attrs.asPath.segments);
-    try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 1), attrs.nexthop);
+    try testing.expectEqual(model.Origin.EGP, attrs.origin.value);
+    try testing.expectEqualSlices(model.ASPathSegment, &[_]model.ASPathSegment{}, attrs.asPath.value.segments);
+    try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 1), attrs.nexthop.value);
 
-    try testing.expectEqual(100, attrs.localPref);
+    try testing.expectEqual(100, attrs.localPref.value);
 
-    try testing.expectEqual(false, attrs.atomicAggregate);
+    try testing.expectEqual(false, attrs.atomicAggregate.?.value);
     try testing.expectEqual(null, attrs.multiExitDiscriminator);
     try testing.expectEqual(null, attrs.aggregator);
 }
@@ -106,13 +106,13 @@ test "Set Route" {
 
     const attrs: PathAttributes = path.attrs;
 
-    try testing.expectEqual(model.Origin.EGP, attrs.origin);
-    try testing.expect(asPath.equal(&attrs.asPath));
-    try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 3), attrs.nexthop);
+    try testing.expectEqual(model.Origin.EGP, attrs.origin.value);
+    try testing.expect(asPath.equal(&attrs.asPath.value));
+    try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 3), attrs.nexthop.value);
 
-    try testing.expectEqual(142, attrs.localPref);
+    try testing.expectEqual(142, attrs.localPref.value);
 
-    try testing.expectEqual(true, attrs.atomicAggregate);
+    try testing.expectEqual(true, attrs.atomicAggregate.?.value);
     try testing.expectEqual(null, attrs.multiExitDiscriminator);
     try testing.expectEqual(null, attrs.aggregator);
 }

--- a/src/rib/common.zig
+++ b/src/rib/common.zig
@@ -46,17 +46,17 @@ pub const RoutePath = struct {
     /// < 0 => self is less prefered than other
     /// = 0 => Tie
     pub fn cmp(self: *const Self, other: *const Self) i32 {
-        const lPrefComp = @as(i32, @intCast(self.attrs.localPref)) - @as(i32, @intCast(other.attrs.localPref));
+        const lPrefComp = @as(i32, @intCast(self.attrs.localPref.value)) - @as(i32, @intCast(other.attrs.localPref.value));
         if (lPrefComp != 0) {
             return lPrefComp;
         }
 
-        const asPathComp: i32 = @as(i32, @intCast(other.attrs.asPath.len())) - @as(i32, @intCast(self.attrs.asPath.len()));
+        const asPathComp: i32 = @as(i32, @intCast(other.attrs.asPath.value.len())) - @as(i32, @intCast(self.attrs.asPath.value.len()));
         if (asPathComp != 0) {
             return asPathComp;
         }
 
-        const originComp = @intFromEnum(other.attrs.origin) - @intFromEnum(self.attrs.origin);
+        const originComp = @intFromEnum(other.attrs.origin.value) - @intFromEnum(self.attrs.origin.value);
         if (originComp != 0) {
             return originComp;
         }
@@ -147,31 +147,31 @@ test "RoutePath.cmp local preference" {
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .IGP,
-            .asPath = ASPath.createEmpty(allocator),
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 200,
-            .atomicAggregate = false,
+            .origin = .init(.IGP),
+            .asPath = .init(ASPath.createEmpty(allocator)),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(200),
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
     };
-    defer path1.attrs.asPath.deinit();
+    defer path1.attrs.asPath.value.deinit();
 
     const path2 = RoutePath{
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .IGP,
-            .asPath = ASPath.createEmpty(allocator),
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 100,
-            .atomicAggregate = false,
+            .origin = .init(.IGP),
+            .asPath = .init(ASPath.createEmpty(allocator)),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(100),
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
     };
-    defer path2.attrs.asPath.deinit();
+    defer path2.attrs.asPath.value.deinit();
 
     try testing.expect(path1.cmp(&path2) > 0);
     try testing.expect(path2.cmp(&path1) < 0);
@@ -195,11 +195,11 @@ test "RoutePath.cmp AS path length" {
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .IGP,
-            .asPath = as_path_long,
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 100,
-            .atomicAggregate = false,
+            .origin = .init(.IGP),
+            .asPath = .init(as_path_long),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(100),
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
@@ -209,16 +209,16 @@ test "RoutePath.cmp AS path length" {
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .IGP,
-            .asPath = ASPath.createEmpty(allocator),
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 100, // Equal localPref
-            .atomicAggregate = false,
+            .origin = .init(.IGP),
+            .asPath = .init(ASPath.createEmpty(allocator)),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(100), // Equal localPref
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
     };
-    defer path_short.attrs.asPath.deinit();
+    defer path_short.attrs.asPath.value.deinit();
 
     try testing.expect(path_short.cmp(&path_long) > 0);
     try testing.expect(path_long.cmp(&path_short) < 0);
@@ -231,46 +231,46 @@ test "RoutePath.cmp origin preference" {
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .IGP,
-            .asPath = ASPath.createEmpty(allocator),
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 100,
-            .atomicAggregate = false,
+            .origin = .init(.IGP),
+            .asPath = .init(ASPath.createEmpty(allocator)),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(100),
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
     };
-    defer path_igp.attrs.asPath.deinit();
+    defer path_igp.attrs.asPath.value.deinit();
 
     const path_egp = RoutePath{
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .EGP,
-            .asPath = ASPath.createEmpty(allocator),
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 100,
-            .atomicAggregate = false,
+            .origin = .init(.EGP),
+            .asPath = .init(ASPath.createEmpty(allocator)),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(100),
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
     };
-    defer path_egp.attrs.asPath.deinit();
+    defer path_egp.attrs.asPath.value.deinit();
 
     const path_inc = RoutePath{
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .INCOMPLETE,
-            .asPath = ASPath.createEmpty(allocator),
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 100,
-            .atomicAggregate = false,
+            .origin = .init(.INCOMPLETE),
+            .asPath = .init(ASPath.createEmpty(allocator)),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(100),
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
     };
-    defer path_inc.attrs.asPath.deinit();
+    defer path_inc.attrs.asPath.value.deinit();
 
     // IGP > EGP > INCOMPLETE
     try testing.expect(path_igp.cmp(&path_egp) > 0);
@@ -285,31 +285,31 @@ test "RoutePath.cmp tie" {
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .IGP,
-            .asPath = ASPath.createEmpty(allocator),
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 100,
-            .atomicAggregate = false,
+            .origin = .init(.IGP),
+            .asPath = .init(ASPath.createEmpty(allocator)),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(100),
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
     };
-    defer path1.attrs.asPath.deinit();
+    defer path1.attrs.asPath.value.deinit();
 
     const path2 = RoutePath{
         .advertiser = .self,
         .attrs = PathAttributes{
             .allocator = allocator,
-            .origin = .IGP,
-            .asPath = ASPath.createEmpty(allocator),
-            .nexthop = ip.IpV4Address.parse("1.1.1.1") catch unreachable,
-            .localPref = 100,
-            .atomicAggregate = false,
+            .origin = .init(.IGP),
+            .asPath = .init(ASPath.createEmpty(allocator)),
+            .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+            .localPref = .init(100),
+            .atomicAggregate = .init(false),
             .multiExitDiscriminator = null,
             .aggregator = null,
         },
     };
-    defer path2.attrs.asPath.deinit();
+    defer path2.attrs.asPath.value.deinit();
 
     try testing.expectEqual(@as(i32, 0), path1.cmp(&path2));
 }

--- a/src/rib/main_rib.zig
+++ b/src/rib/main_rib.zig
@@ -153,6 +153,7 @@ pub const Rib = struct {
 };
 
 const testing = std.testing;
+const t = testing;
 
 test "Add Route" {
     var rib: Rib = .init(testing.allocator);
@@ -160,7 +161,7 @@ test "Add Route" {
 
     const route: Route = .default;
 
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = .createEmpty(testing.allocator), .nexthop = ip.IpV4Address.init(127, 0, 0, 1), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(t.allocator)), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
 
     const ribEntry = rib.prefixes.getPtr(route) orelse return error.RouteNotPresent;
     try testing.expectEqual(ribEntry.route, Route.default);
@@ -200,9 +201,9 @@ test "Set Route" {
     };
     defer asPath.deinit();
 
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(127, 0, 0, 1), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null });
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 2) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(127, 0, 0, 2), .localPref = 200, .atomicAggregate = true, .multiExitDiscriminator = 69420, .aggregator = null });
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(127, 0, 0, 1), .localPref = 142, .atomicAggregate = true, .multiExitDiscriminator = null, .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 2) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 2)), .localPref = .init(200), .atomicAggregate = null, .multiExitDiscriminator = .init(69420), .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(142), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
 
     const ribEntry = rib.prefixes.getPtr(route) orelse return error.RouteNotPresent;
     try testing.expectEqual(ribEntry.route, Route.default);
@@ -247,8 +248,8 @@ test "Remove Path" {
 
     const route: Route = .default;
 
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = .createEmpty(testing.allocator), .nexthop = ip.IpV4Address.init(127, 0, 0, 1), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null });
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 2) } }, .{ .allocator = testing.allocator, .origin = .EGP, .asPath = .createEmpty(testing.allocator), .nexthop = ip.IpV4Address.init(127, 0, 0, 1), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(t.allocator)), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 2) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(t.allocator)), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
 
     try testing.expectEqual(false, rib.removePath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }));
 

--- a/src/rib/main_rib.zig
+++ b/src/rib/main_rib.zig
@@ -161,7 +161,7 @@ test "Add Route" {
 
     const route: Route = .default;
 
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(t.allocator)), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(.createEmpty(t.allocator)), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null });
 
     const ribEntry = rib.prefixes.getPtr(route) orelse return error.RouteNotPresent;
     try testing.expectEqual(ribEntry.route, Route.default);
@@ -171,13 +171,13 @@ test "Add Route" {
 
     const attrs: PathAttributes = routePath.attrs;
 
-    try testing.expectEqual(model.Origin.EGP, attrs.origin);
-    try testing.expectEqualSlices(model.ASPathSegment, &[_]model.ASPathSegment{}, attrs.asPath.segments);
-    try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 1), attrs.nexthop);
+    try testing.expectEqual(model.Origin.EGP, attrs.origin.value);
+    try testing.expectEqualSlices(model.ASPathSegment, &[_]model.ASPathSegment{}, attrs.asPath.value.segments);
+    try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 1), attrs.nexthop.value);
 
-    try testing.expectEqual(100, attrs.localPref);
+    try testing.expectEqual(100, attrs.localPref.value);
 
-    try testing.expectEqual(false, attrs.atomicAggregate);
+    try testing.expectEqual(false, attrs.atomicAggregate.?.value);
     try testing.expectEqual(null, attrs.multiExitDiscriminator);
     try testing.expectEqual(null, attrs.aggregator);
 }
@@ -201,9 +201,9 @@ test "Set Route" {
     };
     defer asPath.deinit();
 
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 2) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 2)), .localPref = .init(200), .atomicAggregate = null, .multiExitDiscriminator = .init(69420), .aggregator = null });
-    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(142), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 2) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 2)), .localPref = .init(200), .atomicAggregate = .init(true), .multiExitDiscriminator = .init(69420), .aggregator = null });
+    try rib.setPath(route, .{ .neighbor = .{ .V4 = .init(127, 0, 0, 1) } }, .{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)), .localPref = .init(142), .atomicAggregate = .init(true), .multiExitDiscriminator = null, .aggregator = null });
 
     const ribEntry = rib.prefixes.getPtr(route) orelse return error.RouteNotPresent;
     try testing.expectEqual(ribEntry.route, Route.default);
@@ -213,13 +213,13 @@ test "Set Route" {
 
         const attrs: PathAttributes = routePath.attrs;
 
-        try testing.expectEqual(model.Origin.EGP, attrs.origin);
-        try testing.expect(asPath.equal(&attrs.asPath));
-        try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 1), attrs.nexthop);
+        try testing.expectEqual(model.Origin.EGP, attrs.origin.value);
+        try testing.expect(asPath.equal(&attrs.asPath.value));
+        try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 1), attrs.nexthop.value);
 
-        try testing.expectEqual(142, attrs.localPref);
+        try testing.expectEqual(142, attrs.localPref.value);
 
-        try testing.expectEqual(true, attrs.atomicAggregate);
+        try testing.expectEqual(true, attrs.atomicAggregate.?.value);
         try testing.expectEqual(null, attrs.multiExitDiscriminator);
         try testing.expectEqual(null, attrs.aggregator);
     }
@@ -230,14 +230,14 @@ test "Set Route" {
 
         const attrs: PathAttributes = routePath.attrs;
 
-        try testing.expectEqual(model.Origin.EGP, attrs.origin);
-        try testing.expect(asPath.equal(&attrs.asPath));
-        try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 2), attrs.nexthop);
+        try testing.expectEqual(model.Origin.EGP, attrs.origin.value);
+        try testing.expect(asPath.equal(&attrs.asPath.value));
+        try testing.expectEqual(ip.IpV4Address.init(127, 0, 0, 2), attrs.nexthop.value);
 
-        try testing.expectEqual(200, attrs.localPref);
+        try testing.expectEqual(200, attrs.localPref.value);
 
-        try testing.expectEqual(true, attrs.atomicAggregate);
-        try testing.expectEqual(69420, attrs.multiExitDiscriminator);
+        try testing.expectEqual(true, attrs.atomicAggregate.?.value);
+        try testing.expectEqual(69420, attrs.multiExitDiscriminator.?.value);
         try testing.expectEqual(null, attrs.aggregator);
     }
 }
@@ -273,11 +273,11 @@ test "Self Advertiser" {
     const route: Route = .default;
     const attrs = model.PathAttributes{
         .allocator = testing.allocator,
-        .origin = .IGP,
-        .asPath = .createEmpty(testing.allocator),
-        .nexthop = ip.IpV4Address.init(127, 0, 0, 1),
-        .localPref = 100,
-        .atomicAggregate = false,
+        .origin = .init(.IGP),
+        .asPath = .init(.createEmpty(testing.allocator)),
+        .nexthop = .init(ip.IpV4Address.init(127, 0, 0, 1)),
+        .localPref = .init(100),
+        .atomicAggregate = .init(false),
         .multiExitDiscriminator = null,
         .aggregator = null,
     };
@@ -288,7 +288,7 @@ test "Self Advertiser" {
     const routePath = ribEntry.paths.getPtr(.self) orelse return error.PathNotFound;
 
     try testing.expect(routePath.advertiser == .self);
-    try testing.expectEqual(model.Origin.IGP, routePath.attrs.origin);
+    try testing.expectEqual(model.Origin.IGP, routePath.attrs.origin.value);
 
     try testing.expectEqual(true, rib.removePath(route, .self));
 }

--- a/src/rib/rib_thread.zig
+++ b/src/rib/rib_thread.zig
@@ -350,16 +350,16 @@ test "Adj -> Main Updates Routes" {
     // Asserts
     try t.expectEqual(adjRib.adjRib.prefixes.count(), 1);
     try t.expectEqual(mainRib.rib.prefixes.count(), 1);
-    try t.expectEqual(110, adjRib.adjRib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.attrs.localPref);
-    try t.expectEqual(100, mainRib.rib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.paths.get(.{ .neighbor = adjRib.neighbor }).?.attrs.localPref);
+    try t.expectEqual(110, adjRib.adjRib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.attrs.localPref.value);
+    try t.expectEqual(100, mainRib.rib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.paths.get(.{ .neighbor = adjRib.neighbor }).?.attrs.localPref.value);
 
     var res = try syncFromAdjInToMain(t.allocator, &adjRib, &mainRib);
     defer res.deinit(t.allocator);
 
     try t.expectEqual(adjRib.adjRib.prefixes.count(), 1);
     try t.expectEqual(mainRib.rib.prefixes.count(), 1);
-    try t.expectEqual(110, adjRib.adjRib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.attrs.localPref);
-    try t.expectEqual(110, mainRib.rib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.paths.get(.{ .neighbor = adjRib.neighbor }).?.attrs.localPref);
+    try t.expectEqual(110, adjRib.adjRib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.attrs.localPref.value);
+    try t.expectEqual(110, mainRib.rib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.paths.get(.{ .neighbor = adjRib.neighbor }).?.attrs.localPref.value);
 }
 
 test "Main Rib Update" {
@@ -454,16 +454,16 @@ test "Main -> Adj Updates Routes" {
     // Asserts
     try t.expectEqual(adjRib.adjRib.prefixes.count(), 1);
     try t.expectEqual(mainRib.rib.prefixes.count(), 1);
-    try t.expectEqual(110, adjRib.adjRib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.attrs.localPref);
-    try t.expectEqual(100, mainRib.rib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.paths.get(.{ .neighbor = adjRib.neighbor }).?.attrs.localPref);
+    try t.expectEqual(110, adjRib.adjRib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.attrs.localPref.value);
+    try t.expectEqual(100, mainRib.rib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.paths.get(.{ .neighbor = adjRib.neighbor }).?.attrs.localPref.value);
 
     var res = try syncFromMainToAdjOut(t.allocator, &adjRib, &mainRib);
     defer res.deinit(t.allocator);
 
     try t.expectEqual(adjRib.adjRib.prefixes.count(), 1);
     try t.expectEqual(mainRib.rib.prefixes.count(), 1);
-    try t.expectEqual(100, adjRib.adjRib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.attrs.localPref);
-    try t.expectEqual(100, mainRib.rib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.paths.get(.{ .neighbor = adjRib.neighbor }).?.attrs.localPref);
+    try t.expectEqual(100, adjRib.adjRib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.attrs.localPref.value);
+    try t.expectEqual(100, mainRib.rib.prefixes.get(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }).?.paths.get(.{ .neighbor = adjRib.neighbor }).?.attrs.localPref.value);
 }
 
 test "aggregateRouteUpdates grouping" {
@@ -474,10 +474,10 @@ test "aggregateRouteUpdates grouping" {
 
     const attrs1 = model.PathAttributes{
         .allocator = alloc,
-        .origin = .IGP,
-        .asPath = try asPath.clone(alloc),
-        .nexthop = ip.IpV4Address.init(1, 1, 1, 1),
-        .localPref = 100,
+        .origin = .init(.IGP),
+        .asPath = .init(try asPath.clone(alloc)),
+        .nexthop = .init(ip.IpV4Address.init(1, 1, 1, 1)),
+        .localPref = .init(100),
         .atomicAggregate = null,
         .multiExitDiscriminator = null,
         .aggregator = null,
@@ -486,10 +486,10 @@ test "aggregateRouteUpdates grouping" {
 
     const attrs2 = model.PathAttributes{
         .allocator = alloc,
-        .origin = .IGP,
-        .asPath = try asPath.clone(alloc),
-        .nexthop = ip.IpV4Address.init(2, 2, 2, 2),
-        .localPref = 100,
+        .origin = .init(.IGP),
+        .asPath = .init(try asPath.clone(alloc)),
+        .nexthop = .init(ip.IpV4Address.init(2, 2, 2, 2)),
+        .localPref = .init(100),
         .atomicAggregate = null,
         .multiExitDiscriminator = null,
         .aggregator = null,
@@ -538,10 +538,10 @@ test "filterSplitHorizon" {
 
     const attrs = model.PathAttributes{
         .allocator = alloc,
-        .origin = .IGP,
-        .asPath = try asPath.clone(alloc),
-        .nexthop = ip.IpV4Address.init(1, 1, 1, 1),
-        .localPref = 100,
+        .origin = .init(.IGP),
+        .asPath = .init(try asPath.clone(alloc)),
+        .nexthop = .init(ip.IpV4Address.init(1, 1, 1, 1)),
+        .localPref = .init(100),
         .atomicAggregate = null,
         .multiExitDiscriminator = null,
         .aggregator = null,

--- a/src/rib/rib_thread.zig
+++ b/src/rib/rib_thread.zig
@@ -294,7 +294,7 @@ test "Adj -> Main Adds Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
+    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null };
 
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, attrs);
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 2, 0 }, .prefixLength = 24 }, attrs);
@@ -319,7 +319,7 @@ test "Adj -> Main Removes Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
+    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null };
 
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, attrs);
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 2, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, attrs);
@@ -341,10 +341,10 @@ test "Adj -> Main Updates Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const mainAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(110), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
+    const mainAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null };
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, mainAttrs);
 
-    const adjAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(110), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
+    const adjAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(110), .atomicAggregate = .init(false), .multiExitDiscriminator = null, .aggregator = null };
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, adjAttrs);
 
     // Asserts

--- a/src/rib/rib_thread.zig
+++ b/src/rib/rib_thread.zig
@@ -294,7 +294,7 @@ test "Adj -> Main Adds Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
 
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, attrs);
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 2, 0 }, .prefixLength = 24 }, attrs);
@@ -319,7 +319,7 @@ test "Adj -> Main Removes Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
 
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, attrs);
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 2, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, attrs);
@@ -341,10 +341,10 @@ test "Adj -> Main Updates Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const mainAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+    const mainAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(110), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, mainAttrs);
 
-    const adjAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 110, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+    const adjAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(110), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, adjAttrs);
 
     // Asserts
@@ -374,8 +374,9 @@ test "Main Rib Update" {
     const route3: model.Route = .{ .prefixData = [4]u8{ 10, 0, 3, 0 }, .prefixLength = 24 };
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
-    const morePrefAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 110, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
-    const lessPredAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+
+    const morePrefAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(110), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
+    const lessPredAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
 
     try mainRib.setPath(route1, neighbor1, morePrefAttrs);
     try mainRib.setPath(route1, neighbor2, lessPredAttrs);
@@ -407,7 +408,7 @@ test "Main -> Adj Adds Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const mainAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+    const mainAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, mainAttrs);
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 2, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, mainAttrs);
 
@@ -425,7 +426,7 @@ test "Main -> Adj Removes Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+    const attrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, attrs);
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 2, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, attrs);
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 2, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, attrs);
@@ -444,10 +445,10 @@ test "Main -> Adj Updates Routes" {
 
     const asPath: model.ASPath = .{ .allocator = t.allocator, .segments = try t.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{}) };
 
-    const mainAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 100, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+    const mainAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(100), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
     try mainRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, mainAttrs);
 
-    const adjAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .EGP, .asPath = asPath, .nexthop = ip.IpV4Address.init(0, 0, 0, 0), .localPref = 110, .atomicAggregate = false, .multiExitDiscriminator = null, .aggregator = null };
+    const adjAttrs = model.PathAttributes{ .allocator = t.allocator, .origin = .init(.EGP), .asPath = .init(asPath), .nexthop = .init(ip.IpV4Address.init(0, 0, 0, 0)), .localPref = .init(110), .atomicAggregate = null, .multiExitDiscriminator = null, .aggregator = null };
     try adjRib.setPath(.{ .prefixData = [4]u8{ 10, 0, 1, 0 }, .prefixLength = 24 }, .{ .neighbor = adjRib.neighbor }, adjAttrs);
 
     // Asserts
@@ -477,7 +478,7 @@ test "aggregateRouteUpdates grouping" {
         .asPath = try asPath.clone(alloc),
         .nexthop = ip.IpV4Address.init(1, 1, 1, 1),
         .localPref = 100,
-        .atomicAggregate = false,
+        .atomicAggregate = null,
         .multiExitDiscriminator = null,
         .aggregator = null,
     };
@@ -489,7 +490,7 @@ test "aggregateRouteUpdates grouping" {
         .asPath = try asPath.clone(alloc),
         .nexthop = ip.IpV4Address.init(2, 2, 2, 2),
         .localPref = 100,
-        .atomicAggregate = false,
+        .atomicAggregate = null,
         .multiExitDiscriminator = null,
         .aggregator = null,
     };
@@ -541,7 +542,7 @@ test "filterSplitHorizon" {
         .asPath = try asPath.clone(alloc),
         .nexthop = ip.IpV4Address.init(1, 1, 1, 1),
         .localPref = 100,
-        .atomicAggregate = false,
+        .atomicAggregate = null,
         .multiExitDiscriminator = null,
         .aggregator = null,
     };


### PR DESCRIPTION
BGP spec mandates that certain flags on attributes be propagated to other peers. For that, we'll need to refactor route attributes so that they carry that information with them.

Changes:
- Created `Attribute` generic struct, which is capable of carrying the flag with itself
- Encapsulated all attributes in the struct