### PR TITLE
Send update messages v1

### DIFF
--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -43,10 +43,12 @@ pub fn writeUpdateBody(msg: model.UpdateMessage, writer: *std.Io.Writer) !void {
     try writer.writeInt(u16, @intCast(calculateRoutesLength(msg.withdrawnRoutes)), .big);
     try writeRoutes(msg.withdrawnRoutes, writer);
 
-    try writer.writeInt(u16, @intCast(calculateAttributesLength(msg.pathAttributes)), .big);
-    try writeAttributes(msg.pathAttributes, writer);
+    if (msg.pathAttributes) |attrs| {
+        try writer.writeInt(u16, @intCast(calculateAttributesLength(attrs)), .big);
+        try writeAttributes(attrs, writer);
 
-    try writeRoutes(msg.advertisedRoutes, writer);
+        try writeRoutes(msg.advertisedRoutes, writer);
+    }
 }
 
 const testing = std.testing;

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -27,23 +27,56 @@ fn writeRoutes(routes: []const model.Route, writer: *std.Io.Writer) !void {
     }
 }
 
-fn calculateAttributesLength(attrs: PathAttributes) usize {
-    // FIXME complete dis
-    _ = attrs;
-    return 0;
+fn calculateAttributesLength(attrs: *const PathAttributes) usize {
+    var result: usize = 0;
+
+    // Origin 
+    result += 2 + 1;
+
+    // AS Path
+    result += 2;
+    for (attrs.asPath.value.segments) |segment| {
+        // Segment Type + Segment length
+        result += 2;
+        result += segment.contents.len * 2;
+    }
+
+    // Nexthop
+    result += 4; // IPv4 Address size
+
+    return result;
 }
 
-fn writeAttributes(attrs: PathAttributes, writer: *std.Io.Writer) !void {
-    // FIXME complete dis
-    _ = attrs;
-    _ = writer;
+fn writeAttributes(attrs: *const PathAttributes, writer: *std.Io.Writer) !void {
+    // TODO: write attribute flags
+
+    // Origin
+    try writer.writeInt(u8, 0, .big);
+    try writer.writeInt(u8, 1, .big);
+    try writer.writeInt(u8, @intFromEnum(attrs.origin.value), .big);
+
+    // AS Path
+    try writer.writeInt(u8, 0, .big);
+    try writer.writeInt(u8, 2, .big);
+    for (attrs.asPath.value.segments) |segment| {
+        try writer.writeInt(u8, @intFromEnum(segment.segType), .big);
+        try writer.writeInt(u8, @intCast(segment.contents.len), .big);
+        for (segment.contents) |asn| {
+            try writer.writeInt(u16, asn, .big);
+        }
+    }
+
+    // Nexthop
+    try writer.writeInt(u8, 0, .big);
+    try writer.writeInt(u8, 3, .big);
+    try writer.writeAll(&attrs.nexthop.value.address);
 }
 
 pub fn writeUpdateBody(msg: model.UpdateMessage, writer: *std.Io.Writer) !void {
     try writer.writeInt(u16, @intCast(calculateRoutesLength(msg.withdrawnRoutes)), .big);
     try writeRoutes(msg.withdrawnRoutes, writer);
 
-    if (msg.pathAttributes) |attrs| {
+    if (msg.pathAttributes) |*attrs| {
         try writer.writeInt(u16, @intCast(calculateAttributesLength(attrs)), .big);
         try writeAttributes(attrs, writer);
 
@@ -114,10 +147,16 @@ test "writeRoutes()" {
 }
 
 test "writeUpdateBody()" {
-    const asPath: AsPath = .{
-        .allocator = testing.allocator,
-        .segments = try testing.allocator.dupe(model.ASPathSegment, &[_]model.ASPathSegment{})
+    const asPath = asPathInit: {
+        const referencePath: AsPath = .{
+            .allocator = testing.allocator,
+            .segments = &[_]model.ASPathSegment{
+                .{.allocator = testing.allocator, .segType = .AS_Set, .contents = &[_]u16{69}}
+            },
+        };
+        break :asPathInit try referencePath.clone(testing.allocator);
     };
+    defer asPath.deinit();
 
     const msg = try model.UpdateMessage.init(
         testing.allocator, 
@@ -152,7 +191,13 @@ test "writeUpdateBody()" {
         16, 0xff, 0xff, 
         12, 0, 0xff, 
         // Attrs
-        0, 0,
+        0, 9+4, 
+        // -- Origin
+        0, 1, 1,
+        // -- As Path
+        0, 2, 1, 1, 0, 69,
+        // -- Next hop
+        0, 3, 0, 0, 0, 0, 
         // Adv
         32, 127, 0, 42, 69, 
         31, 127, 0, 42, 69 

--- a/src/messaging/model.zig
+++ b/src/messaging/model.zig
@@ -96,7 +96,7 @@ pub const Origin = enum(u8) {
     INCOMPLETE = 2,
 };
 
-pub const ASPathSegmentType = enum { AS_Set, AS_Sequence };
+pub const ASPathSegmentType = enum(u8) { AS_Set = 1, AS_Sequence = 2 };
 pub const ASPathSegment = struct {
     const Self = @This();
 
@@ -288,6 +288,8 @@ pub const PathAttributes = struct {
 
     // Optional, transitive
     aggregator: ?Attribute(Aggregator),
+
+    // TODO: For well-known attributes, the Transitive bit MUST be set to 1.
 
     // TODO: track partial bit in recognised attrs
     // If a path with a recognized, transitive optional attribute is accepted

--- a/src/rib/rib_thread.zig
+++ b/src/rib/rib_thread.zig
@@ -219,21 +219,22 @@ fn mainRibThread(ctx: RibThreadContext) !void {
     defer ctx.adjRib.ribMutex.unlock();
 
     // sync adj-in -> main rib
-    var peerIt = ctx.peerMap.valueIterator();
-    while (peerIt.next()) |peer| {
+    var entryIt = ctx.peerMap.iterator();
+    while (entryIt.next()) |entry| {
+        const peer = entry.value_ptr.*;
         // Lock the session to grab the adjIn reference
-        peer.*.session.mutex.lock();
-        if (peer.*.session.state != .ESTABLISHED) {
+        peer.session.mutex.lock();
+        if (peer.session.state != .ESTABLISHED) {
             continue;
         }
 
-        const adjIn = &peer.*.session.adjRibInManager.?;
+        const adjIn = &peer.session.adjRibInManager.?;
         adjIn.ribMutex.lock();
         defer adjIn.ribMutex.unlock();
 
         // Once we grab the adjIn and lock it we can unlock the session
         // While the adjIn is locked the session can't terminate
-        peer.*.session.mutex.unlock();
+        peer.session.mutex.unlock();
 
         const result = try syncFromAdjInToMain(ctx.allocator, adjIn, ctx.mainRib);
         result.deinit(ctx.allocator);
@@ -244,21 +245,24 @@ fn mainRibThread(ctx: RibThreadContext) !void {
     defer updatedRoutes.deinit(ctx.allocator);
 
     // sync main -> adj-out ribs
-    peerIt = ctx.peerMap.valueIterator();
-    while (peerIt.next()) |peer| {
+    entryIt = ctx.peerMap.iterator();
+    while (entryIt.next()) |entry| {
+        const peer = entry.value_ptr.*;
+        const key = entry.key_ptr;
+
         // Lock the session to grab the adjIn reference
-        peer.*.session.mutex.lock();
-        if (peer.*.session.state != .ESTABLISHED) {
+        peer.session.mutex.lock();
+        if (peer.session.state != .ESTABLISHED) {
             continue;
         }
 
-        const adjOut = &peer.*.session.adjRibOutManager.?;
+        const adjOut = &peer.session.adjRibOutManager.?;
         adjOut.ribMutex.lock();
         defer adjOut.ribMutex.unlock();
 
         // Once we grab the adjOut and lock it we can unlock the session
         // While the adjOut is locked the session can't terminate
-        peer.*.session.mutex.unlock();
+        peer.session.mutex.unlock();
 
         const result = try syncFromMainToAdjOut(ctx.allocator, adjOut, ctx.mainRib);
         defer result.deinit(ctx.allocator);
@@ -280,10 +284,16 @@ fn mainRibThread(ctx: RibThreadContext) !void {
             peer.*.session.sendMessage(.{ .UPDATE = .init(ctx.allocator, &[_]model.Route{deletedRoute}, &[_]model.Route{}, null) });
         }
         for (result.updatedRoutes) |update| {
-            // TODO: overwrite the NEXT_HOP attr when sending
-            // TODO: ASN Prepend
-            // Should set to the local address for the peer's session
-            peer.*.session.sendMessage(.{ .UPDATE = .init(ctx.allocator, &[_]model.Route{}, &[_]model.Route{update.@"0"}, update.@"1") });
+            var attrs = update.@"1".clone(ctx.allocator);
+            attrs.nexthop.value = key.localAddress;
+            attrs.asPath.value.prependASN(peer.localAsn);
+
+            peer.*.session.sendMessage(.{ .UPDATE = .{ 
+                .allocator = ctx.allocator, 
+                .withdrawnRoutes = &[_]model.Route{}, 
+                .advertisedRoutes = &[_]model.Route{update.@"0"},
+                .pathAttributes = attrs 
+            } });
         }
     }
 }

--- a/src/rib/rib_thread.zig
+++ b/src/rib/rib_thread.zig
@@ -281,6 +281,7 @@ fn mainRibThread(ctx: RibThreadContext) !void {
         }
         for (result.updatedRoutes) |update| {
             // TODO: overwrite the NEXT_HOP attr when sending
+            // TODO: ASN Prepend
             // Should set to the local address for the peer's session
             peer.*.session.sendMessage(.{ .UPDATE = .init(ctx.allocator, &[_]model.Route{}, &[_]model.Route{update.@"0"}, update.@"1") });
         }

--- a/src/rib/rib_thread.zig
+++ b/src/rib/rib_thread.zig
@@ -281,14 +281,14 @@ fn mainRibThread(ctx: RibThreadContext) !void {
 
         // TODO: Message packaging, one message per prefix is naive
         for (result.deletedRoutes) |deletedRoute| {
-            peer.*.session.sendMessage(.{ .UPDATE = .init(ctx.allocator, &[_]model.Route{deletedRoute}, &[_]model.Route{}, null) });
+            peer.session.sendMessage(.{ .UPDATE = .init(ctx.allocator, &[_]model.Route{deletedRoute}, &[_]model.Route{}, null) });
         }
         for (result.updatedRoutes) |update| {
             var attrs = update.@"1".clone(ctx.allocator);
             attrs.nexthop.value = key.localAddress;
             attrs.asPath.value.prependASN(peer.localAsn);
 
-            peer.*.session.sendMessage(.{ .UPDATE = .{ 
+            peer.session.sendMessage(.{ .UPDATE = .{ 
                 .allocator = ctx.allocator, 
                 .withdrawnRoutes = &[_]model.Route{}, 
                 .advertisedRoutes = &[_]model.Route{update.@"0"},

--- a/src/sessions/session.zig
+++ b/src/sessions/session.zig
@@ -439,7 +439,7 @@ pub const Session = struct {
         }
 
         for (msg.advertisedRoutes) |route| {
-            try self.adjRibInManager.?.setPath(route, msg.pathAttributes);
+            try self.adjRibInManager.?.setPath(route, msg.pathAttributes.?);
         }
     }
 };


### PR DESCRIPTION
Finishing touches for sending valid UPDATE messages:
- Implemented encoding for the 3 mandatory attributes
- Prepend AS Path before sending update
- Replace NEXTHOP attribute with the local address