### PR TITLE
Refactor Update Message

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -257,5 +257,6 @@ test {
     _ = @import("rib/adj_rib.zig");
     _ = @import("rib/rib_thread.zig");
     _ = @import("rib/common.zig");
+    _ = @import("rib/model.zig");
     _ = @import("rib/utils.zig");
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -133,6 +133,7 @@ pub fn main() !void {
     const localPort = processConfig.localConfig.localPort orelse 179;
 
     var mainRib = try ribManager.RibManager.init(gpa);
+    defer mainRib.deinit();
 
     std.log.info("Initializing peer map", .{});
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -256,4 +256,5 @@ test {
     _ = @import("rib/adj_rib.zig");
     _ = @import("rib/rib_thread.zig");
     _ = @import("rib/common.zig");
+    _ = @import("rib/utils.zig");
 }

--- a/src/messaging/encoding/encoder.zig
+++ b/src/messaging/encoding/encoder.zig
@@ -21,7 +21,7 @@ pub const MessageEncoder = struct {
 
     pub fn deinit(_: Self) void {}
 
-    pub fn writeMessage(self: *Self, ctx: model.MessageContext, msg: model.BgpMessage, messageWriter: *std.io.Writer) !void {
+    pub fn writeMessage(self: *Self, msg: model.BgpMessage, messageWriter: *std.io.Writer) !void {
         // TODO implement message size limits
 
         // TODO decide if I want to allocate a buffer everytime or just get a
@@ -40,7 +40,7 @@ pub const MessageEncoder = struct {
                 try notificationMessage.writeNotification(notification, bodyWriterItf);
             },
             .UPDATE => |update| {
-                try updateMessage.writeUpdateBody(ctx, update, bodyWriterItf);
+                try updateMessage.writeUpdateBody(update, bodyWriterItf);
             },
             .KEEPALIVE => {},
         }

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -113,7 +113,7 @@ fn writeAttributes(attrs: *const AttributeList, writer: *std.Io.Writer) !void {
                 try writer.writeInt(u8, med.flags, .big);
                 try writer.writeInt(u8, 4, .big);
                 try writer.writeInt(u8, 4, .big);
-                try writer.writeInt(u32, med.value.value, .big);
+                try writer.writeInt(u32, med.value, .big);
             },
             .LocalPref => |*localPref| {
                 try writer.writeInt(u8, localPref.flags, .big);

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -9,7 +9,7 @@ const AttributeList = messageModel.AttributeList;
 
 const AsPath = ribModel.ASPath;
 
-fn calculateRoutesLength(routes: []const messageModel.Route) usize {
+fn calculateRoutesLength(routes: []const ribModel.Route) usize {
     var total: usize = 0;
     for (routes) |route| {
         total += 1;
@@ -21,7 +21,7 @@ fn calculateRoutesLength(routes: []const messageModel.Route) usize {
     return total;
 }
 
-fn writeRoutes(routes: []const messageModel.Route, writer: *std.Io.Writer) !void {
+fn writeRoutes(routes: []const ribModel.Route, writer: *std.Io.Writer) !void {
     for (routes) |route| {
         try writer.writeInt(u8, route.prefixLength, .big);
 
@@ -84,7 +84,7 @@ fn writeAttributes(attrs: *const AttributeList, writer: *std.Io.Writer) !void {
                 const asPathDataLen = calculateASPathByteLength(&asPath.value);
                 const isExtendedLen = asPathDataLen > 255;
                 if (isExtendedLen) {
-                    try writer.writeInt(u8, asPath.flags | messageModel.ATTR_EXTENDED_LENGTH_FLAG, .big);
+                    try writer.writeInt(u8, asPath.flags | ribModel.ATTR_EXTENDED_LENGTH_FLAG, .big);
                 } else {
                     try writer.writeInt(u8, asPath.flags, .big);
                 }

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -213,7 +213,7 @@ test "writeUpdateBody() - External Peer" {
     try list.append(testing.allocator, .{ .Nexthop = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
     const attrs = AttributeList{ .alloc = testing.allocator, .list = list };
 
-    const msg = try messageModel.UpdateMessage.init(
+    var msg = try messageModel.UpdateMessage.init(
         testing.allocator, 
         &[_]ribModel.Route{ 
             ribModel.Route{
@@ -286,7 +286,7 @@ test "writeUpdateBody() - Internal Peer" {
     try list.append(testing.allocator, .{ .LocalPref = .init(100) });
     const attrs = AttributeList{ .alloc = testing.allocator, .list = list };
 
-    const msg = try messageModel.UpdateMessage.init(
+    var msg = try messageModel.UpdateMessage.init(
         testing.allocator, 
         &[_]ribModel.Route{ 
             ribModel.Route{

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -44,21 +44,23 @@ fn calculateAttributesLength(attrs: *const AttributeList) usize {
     var result: usize = 0;
 
     for (attrs.list.items) |*attr| {
-        result += size: switch (attr.*) {
-            .Origin => 4, // Origin: Flags(1) + Type(1) + Len(1) + Val(1)
+        const dataLength: usize = size: switch (attr.*) {
+            .Origin => 1,
             .AsPath => |*asPath| {
-                // AS Path: Flags(1) + Type(1) + Len(1 or 2) + Data
-                const asPathDataLen = calculateASPathByteLength(&asPath.value);
-                var tmp: usize = 0;
-                tmp += 2; // Flags + Type
-                tmp += if (asPathDataLen > 255) @as(usize, 2) else @as(usize, 1); // Length field
-                tmp += asPathDataLen;
-                break :size tmp;
+                break :size calculateASPathByteLength(&asPath.value);
             },
-            .Nexthop => 7, // Nexthop: Flags(1) + Type(1) + Len(1) + Val(4)
-            .LocalPref => 7,
-            else => 0,
+            .Nexthop => 4,
+            .MultiExitDiscriminator => 4,
+            .LocalPref => 4,
+            .AtomicAggregate => 0,
+            .Aggregator => 6,
+            .Unknown => |*uk| {
+                break :size uk.value.value.len;
+            }
         };
+
+        const lengthFieldSize: usize = if (dataLength > 255) 2 else 1;
+        result += 2 + lengthFieldSize + dataLength;
     }
 
     return result;
@@ -71,22 +73,21 @@ fn writeLocalPref(writer: *std.Io.Writer, localPref: * const ribModel.LocalPrefA
 fn writeAttributes(attrs: *const AttributeList, writer: *std.Io.Writer) !void {
     // TODO: For well-known attributes, the Transitive bit MUST be set to 1.
 
-    for (attrs.list.items) |*attr| {
-        switch (attr.*) {
-            .Origin => |*origin| {
+    for (attrs.list.items) |attr| {
+        switch (attr) {
+            .Origin => |origin| {
                 try writer.writeInt(u8, origin.flags, .big);
                 try writer.writeInt(u8, 1, .big);
                 try writer.writeInt(u8, 1, .big);
                 try writer.writeInt(u8, @intFromEnum(origin.value), .big);
             },
-            .AsPath => |*asPath| {
-                // AS Path
+            .AsPath => |asPath| {
                 const asPathDataLen = calculateASPathByteLength(&asPath.value);
                 const isExtendedLen = asPathDataLen > 255;
                 if (isExtendedLen) {
                     try writer.writeInt(u8, asPath.flags | ribModel.ATTR_EXTENDED_LENGTH_FLAG, .big);
                 } else {
-                    try writer.writeInt(u8, asPath.flags, .big);
+                    try writer.writeInt(u8, asPath.flags & (~ribModel.ATTR_EXTENDED_LENGTH_FLAG), .big);
                 }
                 try writer.writeInt(u8, 2, .big);
                 if (isExtendedLen) {
@@ -102,11 +103,17 @@ fn writeAttributes(attrs: *const AttributeList, writer: *std.Io.Writer) !void {
                     }
                 }
             },
-            .Nexthop => |*nexthop| {
+            .Nexthop => |nexthop| {
                 try writer.writeInt(u8, nexthop.flags, .big);
                 try writer.writeInt(u8, 3, .big);
                 try writer.writeInt(u8, 4, .big);
                 try writer.writeAll(&nexthop.value.address);
+            },
+            .MultiExitDiscriminator=> |med| {
+                try writer.writeInt(u8, med.flags, .big);
+                try writer.writeInt(u8, 4, .big);
+                try writer.writeInt(u8, 4, .big);
+                try writer.writeInt(u32, med.value.value, .big);
             },
             .LocalPref => |*localPref| {
                 try writer.writeInt(u8, localPref.flags, .big);
@@ -114,7 +121,36 @@ fn writeAttributes(attrs: *const AttributeList, writer: *std.Io.Writer) !void {
                 try writer.writeInt(u8, 4, .big);
                 try writeLocalPref(writer, localPref);
             },
-            else => {},
+            .AtomicAggregate => |aAgg| {
+                try writer.writeInt(u8, aAgg.flags, .big);
+                try writer.writeInt(u8, 6, .big);
+                try writer.writeInt(u8, 0, .big);
+            },
+            .Aggregator => |agg| {
+                try writer.writeInt(u8, agg.flags, .big);
+                try writer.writeInt(u8, 7, .big);
+                try writer.writeInt(u8, 6, .big);
+                try writer.writeInt(u16, agg.value.as, .big);
+                try writer.writeAll(&agg.value.address.address);
+            },
+            .Unknown => |uk| {
+                const isExtendedLen = uk.value.value.len > 255;
+                if (isExtendedLen) {
+                    try writer.writeInt(u8, uk.flags | ribModel.ATTR_EXTENDED_LENGTH_FLAG, .big);
+                } else {
+                    try writer.writeInt(u8, uk.flags & (~ribModel.ATTR_EXTENDED_LENGTH_FLAG), .big);
+                }
+
+                try writer.writeInt(u8, uk.value.typeCode, .big); // Type
+
+                if (isExtendedLen) {
+                    try writer.writeInt(u16, @intCast(uk.value.value.len), .big);
+                } else {
+                    try writer.writeInt(u8, @intCast(uk.value.value.len), .big);
+                }
+
+                try writer.writeAll(uk.value.value);
+            }
         }
     }
 }
@@ -128,6 +164,10 @@ pub fn writeUpdateBody(msg: messageModel.UpdateMessage, writer: *std.Io.Writer) 
     try writer.writeInt(u16, @intCast(calculateRoutesLength(msg.withdrawnRoutes)), .big);
     try writeRoutes(msg.withdrawnRoutes, writer);
 
+    // FIXME: Maybe it'll be better in the long run to just pre-write to buffer
+    // and print out the buffer length, instead of keeping two different
+    // implementations of kinda the same thing. Although it does have the
+    // benefit of little to no allocs
     try writer.writeInt(u16, @intCast(calculateAttributesLength(&msg.pathAttributes)), .big);
     try writeAttributes(&msg.pathAttributes, writer);
 

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -137,21 +137,21 @@ pub fn writeUpdateBody(msg: messageModel.UpdateMessage, writer: *std.Io.Writer) 
 const testing = std.testing;
 
 test "calculateRoutesLength()" {
-    try testing.expectEqual(0, calculateRoutesLength(&[_]messageModel.Route{}));
-    try testing.expectEqual(16, calculateRoutesLength(&[_]messageModel.Route{
-        messageModel.Route{
+    try testing.expectEqual(0, calculateRoutesLength(&[_]ribModel.Route{}));
+    try testing.expectEqual(16, calculateRoutesLength(&[_]ribModel.Route{
+        ribModel.Route{
             .prefixLength = 16,
             .prefixData = [4]u8{ 0, 0, 0, 0 },
         },
-        messageModel.Route{
+        ribModel.Route{
             .prefixLength = 12,
             .prefixData = [4]u8{ 0, 0, 0, 0 },
         },
-        messageModel.Route{
+        ribModel.Route{
             .prefixLength = 32,
             .prefixData = [4]u8{ 0, 0, 0, 0 },
         },
-        messageModel.Route{
+        ribModel.Route{
             .prefixLength = 31,
             .prefixData = [4]u8{ 0, 0, 0, 0 },
         },
@@ -159,20 +159,20 @@ test "calculateRoutesLength()" {
 }
 
 test "writeRoutes()" {
-    const testRoutes = [_]messageModel.Route{
-        messageModel.Route{
+    const testRoutes = [_]ribModel.Route{
+        ribModel.Route{
             .prefixLength = 16,
             .prefixData = [4]u8{ 0xff, 0xff, 0, 0 },
         },
-        messageModel.Route{
+        ribModel.Route{
             .prefixLength = 12,
             .prefixData = [4]u8{ 0, 0xff, 0, 0 },
         },
-        messageModel.Route{
+        ribModel.Route{
             .prefixLength = 32,
             .prefixData = [4]u8{ 127, 0, 42, 69 },
         },
-        messageModel.Route{
+        ribModel.Route{
             .prefixLength = 31,
             .prefixData = [4]u8{ 127, 0, 42, 69 },
         },
@@ -200,7 +200,7 @@ test "writeUpdateBody() - External Peer" {
     const asPath = asPathInit: {
         const referencePath: AsPath = .{
             .allocator = testing.allocator,
-            .segments = &[_]messageModel.ASPathSegment{
+            .segments = &[_]ribModel.ASPathSegment{
                 .{.allocator = testing.allocator, .segType = .AS_Set, .contents = &[_]u16{69}}
             },
         };
@@ -208,30 +208,29 @@ test "writeUpdateBody() - External Peer" {
     };
 
     var list = std.ArrayListUnmanaged(PathAttribute){};
-    try list.append(testing.allocator, .{ .Origin = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = .EGP } });
-    try list.append(testing.allocator, .{ .AsPath = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = asPath } });
-    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
-    try list.append(testing.allocator, .{ .LocalPref = .init(100) });
+    try list.append(testing.allocator, .{ .Origin = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = .EGP } });
+    try list.append(testing.allocator, .{ .AsPath = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = asPath } });
+    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
     const attrs = AttributeList{ .alloc = testing.allocator, .list = list };
 
     const msg = try messageModel.UpdateMessage.init(
         testing.allocator, 
-        &[_]messageModel.Route{ 
-            messageModel.Route{
+        &[_]ribModel.Route{ 
+            ribModel.Route{
                 .prefixLength = 16,
                 .prefixData = [4]u8{ 0xff, 0xff, 0, 0 },
             }, 
-            messageModel.Route{
+            ribModel.Route{
                 .prefixLength = 12,
                 .prefixData = [4]u8{ 0, 0xff, 0, 0 },
             } 
         }, 
-        &[_]messageModel.Route{
-            messageModel.Route{
+        &[_]ribModel.Route{
+            ribModel.Route{
                 .prefixLength = 32,
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
-            messageModel.Route{
+            ribModel.Route{
                 .prefixLength = 31,
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
@@ -273,7 +272,7 @@ test "writeUpdateBody() - Internal Peer" {
     const asPath = asPathInit: {
         const referencePath: AsPath = .{
             .allocator = testing.allocator,
-            .segments = &[_]messageModel.ASPathSegment{
+            .segments = &[_]ribModel.ASPathSegment{
                 .{.allocator = testing.allocator, .segType = .AS_Set, .contents = &[_]u16{69}}
             },
         };
@@ -281,30 +280,30 @@ test "writeUpdateBody() - Internal Peer" {
     };
 
     var list = std.ArrayListUnmanaged(PathAttribute){};
-    try list.append(testing.allocator, .{ .Origin = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = .EGP } });
-    try list.append(testing.allocator, .{ .AsPath = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = asPath } });
-    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
+    try list.append(testing.allocator, .{ .Origin = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = .EGP } });
+    try list.append(testing.allocator, .{ .AsPath = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = asPath } });
+    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
     try list.append(testing.allocator, .{ .LocalPref = .init(100) });
     const attrs = AttributeList{ .alloc = testing.allocator, .list = list };
 
     const msg = try messageModel.UpdateMessage.init(
         testing.allocator, 
-        &[_]messageModel.Route{ 
-            messageModel.Route{
+        &[_]ribModel.Route{ 
+            ribModel.Route{
                 .prefixLength = 16,
                 .prefixData = [4]u8{ 0xff, 0xff, 0, 0 },
             }, 
-            messageModel.Route{
+            ribModel.Route{
                 .prefixLength = 12,
                 .prefixData = [4]u8{ 0, 0xff, 0, 0 },
             } 
         }, 
-        &[_]messageModel.Route{
-            messageModel.Route{
+        &[_]ribModel.Route{
+            ribModel.Route{
                 .prefixLength = 32,
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
-            messageModel.Route{
+            ribModel.Route{
                 .prefixLength = 31,
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -1,12 +1,15 @@
 const std = @import("std");
 const ip = @import("ip");
 const consts = @import("../consts.zig");
-const model = @import("../model.zig");
+const messageModel = @import("../model.zig");
+const ribModel = @import("../../rib/model.zig");
 
-const PathAttributes = model.PathAttributes;
-const AsPath = model.ASPath;
+const PathAttribute = messageModel.PathAttribute;
+const AttributeList = messageModel.AttributeList;
 
-fn calculateRoutesLength(routes: []const model.Route) usize {
+const AsPath = ribModel.ASPath;
+
+fn calculateRoutesLength(routes: []const messageModel.Route) usize {
     var total: usize = 0;
     for (routes) |route| {
         total += 1;
@@ -18,7 +21,7 @@ fn calculateRoutesLength(routes: []const model.Route) usize {
     return total;
 }
 
-fn writeRoutes(routes: []const model.Route, writer: *std.Io.Writer) !void {
+fn writeRoutes(routes: []const messageModel.Route, writer: *std.Io.Writer) !void {
     for (routes) |route| {
         try writer.writeInt(u8, route.prefixLength, .big);
 
@@ -37,115 +40,118 @@ fn calculateASPathByteLength(asPath: *const AsPath) usize {
     return result;
 }
 
-fn calculateAttributesLength(ctx: model.MessageContext, attrs: *const PathAttributes) usize {
+fn calculateAttributesLength(attrs: *const AttributeList) usize {
     var result: usize = 0;
 
-    // Origin: Flags(1) + Type(1) + Len(1) + Val(1)
-    result += 4;
-
-    // AS Path: Flags(1) + Type(1) + Len(1 or 2) + Data
-    const asPathDataLen = calculateASPathByteLength(&attrs.asPath.value);
-    result += 2; // Flags + Type
-    result += if (asPathDataLen > 255) @as(usize, 2) else @as(usize, 1); // Length field
-    result += asPathDataLen;
-
-    // Nexthop: Flags(1) + Type(1) + Len(1) + Val(4)
-    result += 7;
-
-    // Local Pref
-    if (ctx.peerType.? == .Internal) {
-        result += 7;
+    for (attrs.list.items) |*attr| {
+        result += size: switch (attr.*) {
+            .Origin => 4, // Origin: Flags(1) + Type(1) + Len(1) + Val(1)
+            .AsPath => |*asPath| {
+                // AS Path: Flags(1) + Type(1) + Len(1 or 2) + Data
+                const asPathDataLen = calculateASPathByteLength(&asPath.value);
+                var tmp: usize = 0;
+                tmp += 2; // Flags + Type
+                tmp += if (asPathDataLen > 255) @as(usize, 2) else @as(usize, 1); // Length field
+                tmp += asPathDataLen;
+                break :size tmp;
+            },
+            .Nexthop => 7, // Nexthop: Flags(1) + Type(1) + Len(1) + Val(4)
+            .LocalPref => 7,
+            else => 0,
+        };
     }
 
     return result;
 }
 
-fn writeLocalPref(writer: *std.Io.Writer, attrs: * const PathAttributes) !void {
-    try writer.writeInt(u32, attrs.localPref.value, .big);
+fn writeLocalPref(writer: *std.Io.Writer, localPref: * const ribModel.LocalPrefAttr) !void {
+    try writer.writeInt(u32, localPref.value, .big);
 }
 
-fn writeAttributes(ctx: model.MessageContext, attrs: *const PathAttributes, writer: *std.Io.Writer) !void {
+fn writeAttributes(attrs: *const AttributeList, writer: *std.Io.Writer) !void {
     // TODO: For well-known attributes, the Transitive bit MUST be set to 1.
 
-    // Origin
-    try writer.writeInt(u8, attrs.origin.flags, .big);
-    try writer.writeInt(u8, 1, .big);
-    try writer.writeInt(u8, 1, .big);
-    try writer.writeInt(u8, @intFromEnum(attrs.origin.value), .big);
-
-    // AS Path
-    const asPath = &attrs.asPath.value;
-    const asPathDataLen = calculateASPathByteLength(asPath);
-    const isExtendedLen = asPathDataLen > 255;
-    if (isExtendedLen) {
-        try writer.writeInt(u8, attrs.asPath.flags | model.ATTR_EXTENDED_LENGTH_FLAG, .big);
-    } else {
-        try writer.writeInt(u8, attrs.asPath.flags, .big);
-    }
-    try writer.writeInt(u8, 2, .big);
-    if (isExtendedLen) {
-        try writer.writeInt(u16, @intCast(asPathDataLen), .big);
-    } else {
-        try writer.writeInt(u8, @intCast(asPathDataLen), .big);
-    }
-    for (asPath.segments) |segment| {
-        try writer.writeInt(u8, @intFromEnum(segment.segType), .big);
-        try writer.writeInt(u8, @intCast(segment.contents.len), .big);
-        for (segment.contents) |asn| {
-            try writer.writeInt(u16, asn, .big);
+    for (attrs.list.items) |*attr| {
+        switch (attr.*) {
+            .Origin => |*origin| {
+                try writer.writeInt(u8, origin.flags, .big);
+                try writer.writeInt(u8, 1, .big);
+                try writer.writeInt(u8, 1, .big);
+                try writer.writeInt(u8, @intFromEnum(origin.value), .big);
+            },
+            .AsPath => |*asPath| {
+                // AS Path
+                const asPathDataLen = calculateASPathByteLength(&asPath.value);
+                const isExtendedLen = asPathDataLen > 255;
+                if (isExtendedLen) {
+                    try writer.writeInt(u8, asPath.flags | messageModel.ATTR_EXTENDED_LENGTH_FLAG, .big);
+                } else {
+                    try writer.writeInt(u8, asPath.flags, .big);
+                }
+                try writer.writeInt(u8, 2, .big);
+                if (isExtendedLen) {
+                    try writer.writeInt(u16, @intCast(asPathDataLen), .big);
+                } else {
+                    try writer.writeInt(u8, @intCast(asPathDataLen), .big);
+                }
+                for (asPath.value.segments) |segment| {
+                    try writer.writeInt(u8, @intFromEnum(segment.segType), .big);
+                    try writer.writeInt(u8, @intCast(segment.contents.len), .big);
+                    for (segment.contents) |asn| {
+                        try writer.writeInt(u16, asn, .big);
+                    }
+                }
+            },
+            .Nexthop => |*nexthop| {
+                try writer.writeInt(u8, nexthop.flags, .big);
+                try writer.writeInt(u8, 3, .big);
+                try writer.writeInt(u8, 4, .big);
+                try writer.writeAll(&nexthop.value.address);
+            },
+            .LocalPref => |*localPref| {
+                try writer.writeInt(u8, localPref.flags, .big);
+                try writer.writeInt(u8, 5, .big);
+                try writer.writeInt(u8, 4, .big);
+                try writeLocalPref(writer, localPref);
+            },
+            else => {},
         }
-    }
-
-    // Nexthop
-    try writer.writeInt(u8, attrs.nexthop.flags, .big);
-    try writer.writeInt(u8, 3, .big);
-    try writer.writeInt(u8, 4, .big);
-    try writer.writeAll(&attrs.nexthop.value.address);
-
-    // Local Pref
-    if (ctx.peerType.? == .Internal) {
-        try writer.writeInt(u8, attrs.localPref.flags, .big);
-        try writer.writeInt(u8, 5, .big);
-        try writer.writeInt(u8, 4, .big);
-        try writeLocalPref(writer, attrs);
     }
 }
 
-pub fn writeUpdateBody(ctx: model.MessageContext, msg: model.UpdateMessage, writer: *std.Io.Writer) !void {
+pub fn writeUpdateBody(msg: messageModel.UpdateMessage, writer: *std.Io.Writer) !void {
     std.log.debug(
-        "sending UPDATE(withdrawn={d}, advertised={d}, origin={s}, aspath={f})", 
-        .{msg.withdrawnRoutes.len, msg.advertisedRoutes.len, @tagName(msg.pathAttributes.?.origin.value), msg.pathAttributes.?.asPath.value} 
+        "sending UPDATE(withdrawn={d}, advertised={d}, attrs count={d})", 
+        .{msg.withdrawnRoutes.len, msg.advertisedRoutes.len, msg.pathAttributes.list.items.len} 
     );
 
     try writer.writeInt(u16, @intCast(calculateRoutesLength(msg.withdrawnRoutes)), .big);
     try writeRoutes(msg.withdrawnRoutes, writer);
 
-    if (msg.pathAttributes) |*attrs| {
-        try writer.writeInt(u16, @intCast(calculateAttributesLength(ctx, attrs)), .big);
-        try writeAttributes(ctx, attrs, writer);
+    try writer.writeInt(u16, @intCast(calculateAttributesLength(&msg.pathAttributes)), .big);
+    try writeAttributes(&msg.pathAttributes, writer);
 
-        try writeRoutes(msg.advertisedRoutes, writer);
-    }
+    try writeRoutes(msg.advertisedRoutes, writer);
 }
 
 const testing = std.testing;
 
 test "calculateRoutesLength()" {
-    try testing.expectEqual(0, calculateRoutesLength(&[_]model.Route{}));
-    try testing.expectEqual(16, calculateRoutesLength(&[_]model.Route{
-        model.Route{
+    try testing.expectEqual(0, calculateRoutesLength(&[_]messageModel.Route{}));
+    try testing.expectEqual(16, calculateRoutesLength(&[_]messageModel.Route{
+        messageModel.Route{
             .prefixLength = 16,
             .prefixData = [4]u8{ 0, 0, 0, 0 },
         },
-        model.Route{
+        messageModel.Route{
             .prefixLength = 12,
             .prefixData = [4]u8{ 0, 0, 0, 0 },
         },
-        model.Route{
+        messageModel.Route{
             .prefixLength = 32,
             .prefixData = [4]u8{ 0, 0, 0, 0 },
         },
-        model.Route{
+        messageModel.Route{
             .prefixLength = 31,
             .prefixData = [4]u8{ 0, 0, 0, 0 },
         },
@@ -153,20 +159,20 @@ test "calculateRoutesLength()" {
 }
 
 test "writeRoutes()" {
-    const testRoutes = [_]model.Route{
-        model.Route{
+    const testRoutes = [_]messageModel.Route{
+        messageModel.Route{
             .prefixLength = 16,
             .prefixData = [4]u8{ 0xff, 0xff, 0, 0 },
         },
-        model.Route{
+        messageModel.Route{
             .prefixLength = 12,
             .prefixData = [4]u8{ 0, 0xff, 0, 0 },
         },
-        model.Route{
+        messageModel.Route{
             .prefixLength = 32,
             .prefixData = [4]u8{ 127, 0, 42, 69 },
         },
-        model.Route{
+        messageModel.Route{
             .prefixLength = 31,
             .prefixData = [4]u8{ 127, 0, 42, 69 },
         },
@@ -194,46 +200,43 @@ test "writeUpdateBody() - External Peer" {
     const asPath = asPathInit: {
         const referencePath: AsPath = .{
             .allocator = testing.allocator,
-            .segments = &[_]model.ASPathSegment{
+            .segments = &[_]messageModel.ASPathSegment{
                 .{.allocator = testing.allocator, .segType = .AS_Set, .contents = &[_]u16{69}}
             },
         };
         break :asPathInit try referencePath.clone(testing.allocator);
     };
-    defer asPath.deinit();
 
-    const msg = try model.UpdateMessage.init(
+    var list = std.ArrayListUnmanaged(PathAttribute){};
+    try list.append(testing.allocator, .{ .Origin = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = .EGP } });
+    try list.append(testing.allocator, .{ .AsPath = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = asPath } });
+    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
+    try list.append(testing.allocator, .{ .LocalPref = .init(100) });
+    const attrs = AttributeList{ .alloc = testing.allocator, .list = list };
+
+    const msg = try messageModel.UpdateMessage.init(
         testing.allocator, 
-        &[_]model.Route{ 
-            model.Route{
+        &[_]messageModel.Route{ 
+            messageModel.Route{
                 .prefixLength = 16,
                 .prefixData = [4]u8{ 0xff, 0xff, 0, 0 },
             }, 
-            model.Route{
+            messageModel.Route{
                 .prefixLength = 12,
                 .prefixData = [4]u8{ 0, 0xff, 0, 0 },
             } 
         }, 
-        &[_]model.Route{
-            model.Route{
+        &[_]messageModel.Route{
+            messageModel.Route{
                 .prefixLength = 32,
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
-            model.Route{
+            messageModel.Route{
                 .prefixLength = 31,
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
         }, 
-        PathAttributes{
-            .allocator = testing.allocator, 
-            .origin = .{ .flags = model.ATTR_TRANSITIVE_FLAG, .value = .EGP }, 
-            .asPath = .{ .flags = model.ATTR_TRANSITIVE_FLAG, .value = asPath }, 
-            .nexthop = .{ .flags = model.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) }, 
-            .localPref = .init(100), 
-            .atomicAggregate = .init(false), 
-            .multiExitDiscriminator = null, 
-            .aggregator = null
-        },
+        attrs,
     );
     defer msg.deinit();
 
@@ -259,8 +262,7 @@ test "writeUpdateBody() - External Peer" {
     var writer = std.Io.Writer.Allocating.init(testing.allocator);
     defer writer.deinit();
 
-    const ctx = model.MessageContext{ .peerType = .External };
-    try writeUpdateBody(ctx, msg, &writer.writer);
+    try writeUpdateBody(msg, &writer.writer);
 
     const writtenBuffer = try writer.toOwnedSlice();
     defer testing.allocator.free(writtenBuffer);
@@ -271,46 +273,43 @@ test "writeUpdateBody() - Internal Peer" {
     const asPath = asPathInit: {
         const referencePath: AsPath = .{
             .allocator = testing.allocator,
-            .segments = &[_]model.ASPathSegment{
+            .segments = &[_]messageModel.ASPathSegment{
                 .{.allocator = testing.allocator, .segType = .AS_Set, .contents = &[_]u16{69}}
             },
         };
         break :asPathInit try referencePath.clone(testing.allocator);
     };
-    defer asPath.deinit();
 
-    const msg = try model.UpdateMessage.init(
+    var list = std.ArrayListUnmanaged(PathAttribute){};
+    try list.append(testing.allocator, .{ .Origin = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = .EGP } });
+    try list.append(testing.allocator, .{ .AsPath = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = asPath } });
+    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = messageModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
+    try list.append(testing.allocator, .{ .LocalPref = .init(100) });
+    const attrs = AttributeList{ .alloc = testing.allocator, .list = list };
+
+    const msg = try messageModel.UpdateMessage.init(
         testing.allocator, 
-        &[_]model.Route{ 
-            model.Route{
+        &[_]messageModel.Route{ 
+            messageModel.Route{
                 .prefixLength = 16,
                 .prefixData = [4]u8{ 0xff, 0xff, 0, 0 },
             }, 
-            model.Route{
+            messageModel.Route{
                 .prefixLength = 12,
                 .prefixData = [4]u8{ 0, 0xff, 0, 0 },
             } 
         }, 
-        &[_]model.Route{
-            model.Route{
+        &[_]messageModel.Route{
+            messageModel.Route{
                 .prefixLength = 32,
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
-            model.Route{
+            messageModel.Route{
                 .prefixLength = 31,
                 .prefixData = [4]u8{ 127, 0, 42, 69 },
             },
         }, 
-        PathAttributes{
-            .allocator = testing.allocator, 
-            .origin = .{ .flags = model.ATTR_TRANSITIVE_FLAG, .value = .EGP }, 
-            .asPath = .{ .flags = model.ATTR_TRANSITIVE_FLAG, .value = asPath }, 
-            .nexthop = .{ .flags = model.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) }, 
-            .localPref = .init(100), 
-            .atomicAggregate = .init(false), 
-            .multiExitDiscriminator = null, 
-            .aggregator = null
-        },
+        attrs,
     );
     // Let's set the flags on localPref to 0x40 (Transitive) just in case, though it's typically 0x40 for well-known
     // Actually the default flags is 0, let's keep it 0 as the other test doesn't set it 
@@ -340,8 +339,7 @@ test "writeUpdateBody() - Internal Peer" {
     var writer = std.Io.Writer.Allocating.init(testing.allocator);
     defer writer.deinit();
 
-    const ctx = model.MessageContext{ .peerType = .Internal };
-    try writeUpdateBody(ctx, msg, &writer.writer);
+    try writeUpdateBody(msg, &writer.writer);
 
     const writtenBuffer = try writer.toOwnedSlice();
     defer testing.allocator.free(writtenBuffer);

--- a/src/messaging/encoding/update.zig
+++ b/src/messaging/encoding/update.zig
@@ -236,67 +236,19 @@ test "writeRoutes()" {
     try testing.expectEqualSlices(u8, &expectedBuffer, writtenBuffer);
 }
 
-test "writeUpdateBody() - External Peer" {
-    const asPath = asPathInit: {
-        const referencePath: AsPath = .{
-            .allocator = testing.allocator,
-            .segments = &[_]ribModel.ASPathSegment{
-                .{.allocator = testing.allocator, .segType = .AS_Set, .contents = &[_]u16{69}}
-            },
-        };
-        break :asPathInit try referencePath.clone(testing.allocator);
-    };
-
-    var list = std.ArrayListUnmanaged(PathAttribute){};
-    try list.append(testing.allocator, .{ .Origin = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = .EGP } });
-    try list.append(testing.allocator, .{ .AsPath = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = asPath } });
-    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
+test "writeUpdateBody() - Minimal (Withdrawn only)" {
+    const list = std.ArrayListUnmanaged(PathAttribute){};
     const attrs = AttributeList{ .alloc = testing.allocator, .list = list };
 
     var msg = try messageModel.UpdateMessage.init(
         testing.allocator, 
-        &[_]ribModel.Route{ 
-            ribModel.Route{
-                .prefixLength = 16,
-                .prefixData = [4]u8{ 0xff, 0xff, 0, 0 },
-            }, 
-            ribModel.Route{
-                .prefixLength = 12,
-                .prefixData = [4]u8{ 0, 0xff, 0, 0 },
-            } 
-        }, 
         &[_]ribModel.Route{
-            ribModel.Route{
-                .prefixLength = 32,
-                .prefixData = [4]u8{ 127, 0, 42, 69 },
-            },
-            ribModel.Route{
-                .prefixLength = 31,
-                .prefixData = [4]u8{ 127, 0, 42, 69 },
-            },
+            .{ .prefixLength = 24, .prefixData = [4]u8{ 10, 0, 0, 0 } },
         }, 
+        &[_]ribModel.Route{}, 
         attrs,
     );
     defer msg.deinit();
-
-    // zig fmt: off
-    const expectedBuffer = [_]u8{ 
-        // Withdrawn
-        0, 6,
-        16, 0xff, 0xff, 
-        12, 0, 0xff, 
-        // Attrs
-        0, 4 + 7 + 7, 
-        // -- Origin (Flags:0x40, Type:1, Len:1, Val:1)
-        0x40, 1, 1, 1,
-        // -- As Path (Flags:0x40, Type:2, Len:4, Val: [AS_SET, 1 ASN, 69])
-        0x40, 2, 4, 1, 1, 0, 69,
-        // -- Next hop (Flags:0x40, Type:3, Len:4, Val: 0.0.0.0)
-        0x40, 3, 4, 0, 0, 0, 0, 
-        // Adv
-        32, 127, 0, 42, 69, 
-        31, 127, 0, 42, 69 
-    };
 
     var writer = std.Io.Writer.Allocating.init(testing.allocator);
     defer writer.deinit();
@@ -305,75 +257,68 @@ test "writeUpdateBody() - External Peer" {
 
     const writtenBuffer = try writer.toOwnedSlice();
     defer testing.allocator.free(writtenBuffer);
+
+    // zig fmt: off
+    const expectedBuffer = [_]u8{ 
+        0, 4,       // Withdrawn len: 4
+        24, 10, 0, 0, 
+        0, 0        // Attrs len: 0
+    };
     try testing.expectEqualSlices(u8, &expectedBuffer, writtenBuffer);
 }
 
-test "writeUpdateBody() - Internal Peer" {
+
+test "writeUpdateBody() - All Attributes" {
     const asPath = asPathInit: {
         const referencePath: AsPath = .{
             .allocator = testing.allocator,
             .segments = &[_]ribModel.ASPathSegment{
-                .{.allocator = testing.allocator, .segType = .AS_Set, .contents = &[_]u16{69}}
+                .{.allocator = testing.allocator, .segType = .AS_Sequence, .contents = &[_]u16{65001}}
             },
         };
         break :asPathInit try referencePath.clone(testing.allocator);
     };
 
+    const unknownExtData = try testing.allocator.alloc(u8, 300);
+    @memset(unknownExtData, 0);
+    defer testing.allocator.free(unknownExtData);
+
     var list = std.ArrayListUnmanaged(PathAttribute){};
-    try list.append(testing.allocator, .{ .Origin = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = .EGP } });
+    try list.append(testing.allocator, .{ .Origin = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = .IGP } });
     try list.append(testing.allocator, .{ .AsPath = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = asPath } });
-    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(0, 0, 0, 0) } });
-    try list.append(testing.allocator, .{ .LocalPref = .init(100) });
+    try list.append(testing.allocator, .{ .Nexthop = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = ip.IpV4Address.init(1, 2, 3, 4) } });
+    try list.append(testing.allocator, .{ .MultiExitDiscriminator = .{ .flags = ribModel.ATTR_OPTIONAL_FLAG, .value = 1234 } });
+    try list.append(testing.allocator, .{ .LocalPref = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = 100 } });
+    try list.append(testing.allocator, .{ .AtomicAggregate = .{ .flags = ribModel.ATTR_TRANSITIVE_FLAG, .value = true } });
+    try list.append(testing.allocator, .{ .Aggregator = .{ 
+        .flags = ribModel.ATTR_OPTIONAL_FLAG | ribModel.ATTR_TRANSITIVE_FLAG, 
+        .value = .{ .as = 65001, .address = ip.IpV4Address.init(1, 2, 3, 4) } 
+    } });
+    try list.append(testing.allocator, .{ .Unknown = .{ 
+        .flags = ribModel.ATTR_OPTIONAL_FLAG, 
+        .value = .{ .allocator = testing.allocator, .typeCode = 100, .value = try testing.allocator.dupe(u8, &[_]u8{ 1, 2, 3 }) } 
+    } });
+    try list.append(testing.allocator, .{ .Unknown = .{ 
+        .flags = ribModel.ATTR_OPTIONAL_FLAG, 
+        .value = .{ .allocator = testing.allocator, .typeCode = 101, .value = try testing.allocator.dupe(u8, unknownExtData) } 
+    } });
+
     const attrs = AttributeList{ .alloc = testing.allocator, .list = list };
 
     var msg = try messageModel.UpdateMessage.init(
         testing.allocator, 
-        &[_]ribModel.Route{ 
-            ribModel.Route{
-                .prefixLength = 16,
-                .prefixData = [4]u8{ 0xff, 0xff, 0, 0 },
-            }, 
-            ribModel.Route{
-                .prefixLength = 12,
-                .prefixData = [4]u8{ 0, 0xff, 0, 0 },
-            } 
+        &[_]ribModel.Route{
+            .{ .prefixLength = 24, .prefixData = [4]u8{ 192, 168, 1, 0 } },
         }, 
         &[_]ribModel.Route{
             ribModel.Route{
                 .prefixLength = 32,
-                .prefixData = [4]u8{ 127, 0, 42, 69 },
-            },
-            ribModel.Route{
-                .prefixLength = 31,
-                .prefixData = [4]u8{ 127, 0, 42, 69 },
+                .prefixData = [4]u8{ 127, 0, 0, 1 },
             },
         }, 
         attrs,
     );
-    // Let's set the flags on localPref to 0x40 (Transitive) just in case, though it's typically 0x40 for well-known
-    // Actually the default flags is 0, let's keep it 0 as the other test doesn't set it 
     defer msg.deinit();
-
-    // zig fmt: off
-    const expectedBuffer = [_]u8{ 
-        // Withdrawn
-        0, 6,
-        16, 0xff, 0xff, 
-        12, 0, 0xff, 
-        // Attrs
-        0, 4 + 7 + 7 + 7, 
-        // -- Origin (Flags:0x40, Type:1, Len:1, Val:1)
-        0x40, 1, 1, 1,
-        // -- As Path (Flags:0x40, Type:2, Len:4, Val: [AS_SET, 1 ASN, 69])
-        0x40, 2, 4, 1, 1, 0, 69,
-        // -- Next hop (Flags:0x40, Type:3, Len:4, Val: 0.0.0.0)
-        0x40, 3, 4, 0, 0, 0, 0, 
-        // -- Local Pref (Flags:0x00, Type:5, Len:4, Val: 100)
-        0x00, 5, 4, 0, 0, 0, 100,
-        // Adv
-        32, 127, 0, 42, 69, 
-        31, 127, 0, 42, 69 
-    };
 
     var writer = std.Io.Writer.Allocating.init(testing.allocator);
     defer writer.deinit();
@@ -382,5 +327,69 @@ test "writeUpdateBody() - Internal Peer" {
 
     const writtenBuffer = try writer.toOwnedSlice();
     defer testing.allocator.free(writtenBuffer);
-    try testing.expectEqualSlices(u8, &expectedBuffer, writtenBuffer);
+
+    // Header: 
+    // Withdrawn len: 0 (2 bytes)
+    // Attrs len: ... (2 bytes)
+    // Attrs:
+    // - Origin: 0x40, 1, 1, 0 (4 bytes)
+    // - As Path: 0x40, 2, 4, 2, 1, 0xFD, 0xE9 (7 bytes)
+    // - Nexthop: 0x40, 3, 4, 1, 2, 3, 4 (7 bytes)
+    // - MED: 0x80, 4, 4, 0, 0, 4, 210 (7 bytes)
+    // - LocalPref: 0x40, 5, 4, 0, 0, 0, 100 (7 bytes)
+    // - AtomicAggregate: 0x40, 6, 0 (3 bytes)
+    // - Aggregator: 0xC0, 7, 6, 0xFD, 0xE9, 1, 2, 3, 4 (9 bytes)
+    // - Unknown (100): 0x80, 100, 3, 1, 2, 3 (6 bytes)
+    // - Unknown (101): 0x90, 101, 1, 44, [0]*300 (4 + 300 = 304 bytes)
+    // Adv: 32, 127, 0, 0, 1 (5 bytes)
+
+    const expected_attrs_len = 4 + 7 + 7 + 7 + 7 + 3 + 9 + 6 + 304; // 354
+    try testing.expectEqual(4, std.mem.readInt(u16, writtenBuffer[0..2], .big)); // Withdrawn len
+    try testing.expectEqualSlices(u8, &[_]u8{ 24, 192, 168, 1 }, writtenBuffer[2..6]);
+    try testing.expectEqual(expected_attrs_len, std.mem.readInt(u16, writtenBuffer[6..8], .big)); // Attrs len
+    
+    // Check specific attributes
+    var offset: usize = 8;
+    
+    // Origin
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x40, 1, 1, 0 }, writtenBuffer[offset .. offset + 4]);
+    offset += 4;
+
+    // AsPath
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x40, 2, 4, 2, 1, 0xFD, 0xE9 }, writtenBuffer[offset .. offset + 7]);
+    offset += 7;
+
+    // Nexthop
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x40, 3, 4, 1, 2, 3, 4 }, writtenBuffer[offset .. offset + 7]);
+    offset += 7;
+
+    // MED
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x80, 4, 4, 0, 0, 4, 210 }, writtenBuffer[offset .. offset + 7]);
+    offset += 7;
+
+    // LocalPref
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x40, 5, 4, 0, 0, 0, 100 }, writtenBuffer[offset .. offset + 7]);
+    offset += 7;
+
+    // AtomicAggregate
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x40, 6, 0 }, writtenBuffer[offset .. offset + 3]);
+    offset += 3;
+
+    // Aggregator
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xC0, 7, 6, 0xFD, 0xE9, 1, 2, 3, 4 }, writtenBuffer[offset .. offset + 9]);
+    offset += 9;
+
+    // Unknown (100)
+    try testing.expectEqualSlices(u8, &[_]u8{ 0x80, 100, 3, 1, 2, 3 }, writtenBuffer[offset .. offset + 6]);
+    offset += 6;
+
+    // Unknown (101) - Extended
+    try testing.expectEqual(0x90, writtenBuffer[offset]);
+    try testing.expectEqual(101, writtenBuffer[offset + 1]);
+    try testing.expectEqual(@as(u16, 300), std.mem.readInt(u16, &[_]u8{writtenBuffer[offset + 2], writtenBuffer[offset + 3]}, .big));
+    try testing.expectEqualSlices(u8, unknownExtData, writtenBuffer[offset + 4 .. offset + 304]);
+    offset += 304;
+
+    // Adv
+    try testing.expectEqualSlices(u8, &[_]u8{ 32, 127, 0, 0, 1 }, writtenBuffer[offset .. offset + 5]);
 }

--- a/src/messaging/encoding/utils/size/update.zig
+++ b/src/messaging/encoding/utils/size/update.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const model = @import("../../../model.zig");
+const model = @import("../../../../rib/model.zig");
 
 fn calculateRouteSize(route: *const model.Route) usize {
     var l = route.prefixLength / 8;

--- a/src/messaging/model.zig
+++ b/src/messaging/model.zig
@@ -3,7 +3,20 @@ const ip = @import("ip");
 
 const sessions = @import("../sessions/session.zig");
 
+const ribModel = @import("../rib/model.zig");
+
 const Allocator = std.mem.Allocator;
+
+const Route = ribModel.Route;
+
+const OriginAttr = ribModel.OriginAttr;
+const AsPathAttr = ribModel.AsPathAttr;
+const NexthopAttr = ribModel.NexthopAttr;
+const LocalPrefAttr = ribModel.LocalPrefAttr;
+const AtomicAggregateAttr = ribModel.AtomicAggregateAttr;
+const MultiExitDiscriminatorAttr = ribModel.MultiExitDiscriminatorAttr;
+const AggregatorAttr = ribModel.AggregatorAttr;
+const UnknownAttr = ribModel.UnknownAttr;
 
 pub const ParameterType = enum(u8) {};
 
@@ -85,379 +98,74 @@ pub const NotificationMessage = struct {
     }
 };
 
-pub const Route = struct {
-    prefixLength: u8,
-    prefixData: [4]u8,
-
-    pub const default: Route = .{ .prefixLength = 0, .prefixData = [_]u8{0} ** 4 };
-};
-
-pub const Origin = enum(u8) {
-    IGP = 0,
-    EGP = 1,
-    INCOMPLETE = 2,
-};
-
-pub const ASPathSegmentType = enum(u8) { AS_Set = 1, AS_Sequence = 2 };
-pub const ASPathSegment = struct {
-    const Self = @This();
-
-    allocator: Allocator,
-
-    segType: ASPathSegmentType,
-    contents: []const u16,
-
-    pub fn deinit(self: Self) void {
-        self.allocator.free(self.contents);
-    }
-
-    pub fn clone(self: Self, allocator: std.mem.Allocator) !Self {
-        return Self{
-            .allocator = allocator,
-            .segType = self.segType,
-            .contents = try allocator.dupe(u16, self.contents),
-        };
-    }
-
-    pub inline fn equal(self: Self, other: Self) bool {
-        if (self.segType != other.segType) {
-            return false;
-        }
-
-        return std.mem.eql(u16, self.contents, other.contents);
-    }
-
-    pub fn hash(self: Self, hasher: anytype) void {
-        std.hash.autoHash(hasher, self.segType);
-        std.hash.autoHash(hasher, self.contents.len);
-        for (self.contents) |item| {
-            std.hash.autoHash(hasher, item);
-        }
-    }
-};
-
-pub const ASPath = struct {
-    // FIXME: Cloning logic should really be tested to ensure stuff lands on separate buffers
-    const Self = @This();
-
-    allocator: Allocator,
-    segments: []const ASPathSegment,
-
-    pub fn deinit(self: Self) void {
-        for (self.segments) |seg| {
-            seg.deinit();
-        }
-        self.allocator.free(self.segments);
-    }
-
-    pub fn clone(self: Self, allocator: std.mem.Allocator) !Self {
-        const newASPath = try allocator.alloc(ASPathSegment, self.segments.len);
-        errdefer allocator.free(newASPath);
-
-        for (0..newASPath.len) |i| {
-            newASPath[i] = try self.segments[i].clone(allocator);
-        }
-
-        return Self{ .allocator = allocator, .segments = newASPath };
-    }
-
-    pub inline fn equal(self: *const Self, other: *const Self) bool {
-        if (self.segments.len != other.segments.len) {
-            return false;
-        }
-
-        for (0..self.segments.len) |i| {
-            if (!self.segments[i].equal(other.segments[i])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    pub fn hash(self: Self, hasher: anytype) void {
-        std.hash.autoHash(hasher, self.segments.len);
-        for (self.segments) |seg| {
-            seg.hash(hasher);
-        }
-    }
-
-    pub fn createEmpty(allocator: Allocator) Self {
-        return Self{
-            .allocator = allocator,
-            .segments = allocator.dupe(ASPathSegment, &[_]ASPathSegment{}) catch {
-                std.debug.print("ERROR ALLOCATING EMPTY SLICE, WTF!!!!!", .{});
-                std.process.abort();
-            },
-        };
-    }
-
-    pub fn len(self: *const Self) usize {
-        var size: usize = 0;
-        for (self.segments) |segment| {
-            switch (segment.segType) {
-                .AS_Sequence => size += segment.contents.len,
-                .AS_Set => size += 1,
-            }
-        }
-        return size;
-    }
-
-    pub fn prependASN(self: *Self, asn: u16) !void {
-        // FIXME: Missing overflow protection (prevent segment length from
-        // going over 255)
-        if (self.segments.len == 0) {
-            const newSegments = try self.allocator.alloc(ASPathSegment, 1);
-
-            const contents = try self.allocator.alloc(u16, 1);
-            contents[0] = asn;
-            newSegments[0] = ASPathSegment{
-                .allocator = self.allocator,
-                .contents = contents,
-                .segType = .AS_Sequence,
-            };
-
-            self.allocator.free(self.segments);
-            self.segments = newSegments;
-            return;
-        }
-
-        switch (self.segments[0].segType) {
-            .AS_Sequence => {
-                var firstSegment = self.segments[0];
-                const newContents = try firstSegment.allocator.alloc(u16, firstSegment.contents.len + 1);
-                newContents[0] = asn;
-                std.mem.copyForwards(u16, newContents[1..], firstSegment.contents);
-                firstSegment.allocator.free(firstSegment.contents);
-                firstSegment.contents = newContents;
-                @constCast(self.segments)[0] = firstSegment;
-            },
-            .AS_Set => {
-                const newSegments = try self.allocator.alloc(ASPathSegment, self.segments.len + 1);
-                std.mem.copyForwards(ASPathSegment, newSegments[1..], self.segments);
-
-                const contents = try self.allocator.alloc(u16, 1);
-                contents[0] = asn;
-                newSegments[0] = ASPathSegment{
-                    .allocator = self.allocator,
-                    .contents = contents,
-                    .segType = .AS_Sequence,
-                };
-
-                self.allocator.free(self.segments);
-                self.segments = newSegments;
-            },
-        }
-    }
-
-    pub fn format(
-        self: *const Self,
-        writer: *std.Io.Writer,
-    ) std.Io.Writer.Error!void {
-        try writer.print("[", .{});
-        for (self.segments, 0..) |segment, segi| {
-            if (segment.segType == .AS_Sequence) {
-                try writer.print("seq{{", .{});
-            } else {
-                try writer.print("set{{", .{});
-            }
-            for (segment.contents, 0..) |asn, asni| {
-                try writer.print("{d}", .{asn});
-                if (asni < segment.contents.len-1) {
-                    try writer.print(", ", .{});
-                }
-            }
-            try writer.print("}}", .{});
-            if (segi < self.segments.len-1) {
-                try writer.print(", ", .{});
-            }
-        }
-        try writer.print("]", .{});
-    }
-};
-
-pub const Aggregator = struct {
-    const Self = @This();
-
-    as: u16,
-    address: ip.IpV4Address,
-
-    pub fn equal(self: *const Self, other: *const Self) bool {
-        return self.as == other.as and self.address.equals(other.address);
-    }
-
-    pub fn hash(self: Self, hasher: anytype) void {
-        std.hash.autoHash(hasher, self.as);
-        std.hash.autoHash(hasher, self.address);
-    }
-};
-
-pub const ATTR_OPTIONAL_FLAG: u8 = 0x80;
-pub const ATTR_TRANSITIVE_FLAG: u8 = 0x40;
-pub const ATTR_PARTIAL_FLAG: u8 = 0x20;
-pub const ATTR_EXTENDED_LENGTH_FLAG: u8 = 0x10;
-pub fn Attribute(comptime AttrType: type) type {
-    return struct {
-        const Self = @This();
-
-        // Flags
-        flags: u8,
-
-        // Value
-        value: AttrType,
-
-        pub fn init(value: AttrType) Self {
-            return Self{
-                .flags = 0x00,
-                .value = value
-            };
-        }
-
-        pub fn isOptional(self: *const Self) bool {
-            return (self.flags & ATTR_OPTIONAL_FLAG) > 0;
-        }
-
-        pub fn isTransitive(self: *const Self) bool {
-            return (self.flags & ATTR_TRANSITIVE_FLAG) > 0;
-        }
-
-        pub fn isExtendedLength(self: *const Self) bool {
-            return (self.flags & ATTR_EXTENDED_LENGTH_FLAG) > 0;
-        }   
-
-        pub fn isPartial(self: *const Self) bool {
-            return (self.flags & ATTR_PARTIAL_FLAG) > 0;
-        }
-    };
-}
-
-fn areOptionalAttrsEqual(comptime Type: type, attr1: ?Attribute(Type), attr2: ?Attribute(Type)) bool {
-    if (attr1) |a1| {
-        if (attr2) |a2| {
-            if (@typeInfo(Type) == .@"struct" and @hasDecl(Type, "equal")) {
-                if (!a1.value.equal(&a2.value)) {
-                    return false;
-                }
-            } else {
-                if (a1.value != a2.value) {
-                    return false;
-                }
-            }
-        }
-    } else {
-        if (attr2 != null) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-pub const PathAttributes = struct {
-    const Self = @This();
-
-    allocator: Allocator,
-
-    // Well known, Mandatory
-    origin: Attribute(Origin),
-    asPath: Attribute(ASPath),
-    nexthop: Attribute(ip.IpV4Address),
+const PathAttribute = union(enum) {
+    Origin: OriginAttr,
+    AsPath: AsPathAttr,
+    Nexthop: NexthopAttr,
 
     // Well known
     // Mandatory for internal peers or confeds
-    localPref: Attribute(u32),
+    LocalPref: LocalPrefAttr,
 
     // Well known, discretionary
-    atomicAggregate: ?Attribute(bool),
+    AtomicAggregate: AtomicAggregateAttr,
 
     // Optional, non-transitive
-    multiExitDiscriminator: ?Attribute(u32),
+    MultiExitDiscriminator: MultiExitDiscriminatorAttr,
 
     // Optional, transitive
-    aggregator: ?Attribute(Aggregator),
+    Aggregator: AggregatorAttr,
 
-    // TODO: track partial bit in recognised attrs
-    // If a path with a recognized, transitive optional attribute is accepted
-    // and passed along to other BGP peers and the Partial bit in the Attribute
-    // Flags octet is set to 1 by some previous AS, it MUST NOT be set back to
-    // 0 by the current AS.
+    Unknown: UnknownAttr,
 
-    // TODO: support unrecognised transitive attributes
-    // If a path with an unrecognized transitive optional attribute is accepted
-    // and passed to other BGP peers, then the unrecognized transitive optional
-    // attribute of that path MUST be passed, along with the path, to other BGP
-    // peers with the Partial bit in the Attribute Flags octet set to 1.
 
-    pub const empty: Self = .{
-        .allocator = undefined,
-        .origin = undefined,
-        .asPath = undefined,
-        .nexthop = undefined,
-        .localPref = .init(100),
-        .atomicAggregate = null,
-        .multiExitDiscriminator = null,
-        .aggregator = null,
-    };
-
-    pub fn deinit(self: Self) void {
-        self.asPath.value.deinit();
+    pub fn deinit(self: *@This()) void {
+        switch (self) {
+            .AsPath => |*asPath| {
+                asPath.value.deinit();
+            },
+            .Unknown => |*unknown| {
+                unknown.value.deinit();
+            },
+            .Origin,
+            .Nexthop,
+            .LocalPref,
+            .AtomicAggregate,
+            .MultiExitDiscriminator,
+            .Aggregator => {}
+        }
     }
 
-    pub fn clone(self: Self, allocator: std.mem.Allocator) !Self {
-        var copy = Self{
-            .allocator = allocator,
-            .origin = self.origin,
-            .asPath = self.asPath,
-            .nexthop = self.nexthop,
-            .localPref = self.localPref,
-            .atomicAggregate = self.atomicAggregate,
-            .multiExitDiscriminator = self.multiExitDiscriminator,
-            .aggregator = self.aggregator,
-        };
-        copy.asPath.value = try self.asPath.value.clone(allocator);
-        return copy;
-    }
-
-    pub fn equal(self: *const Self, other: *const Self) bool {
-        if (self.origin.value != other.origin.value) return false;
-        if (!self.asPath.value.equal(&other.asPath.value)) return false;
-        if (!self.nexthop.value.equals(other.nexthop.value)) return false;
-        if (self.localPref.value != other.localPref.value) return false;
-
-        if (!areOptionalAttrsEqual(bool, self.atomicAggregate, other.atomicAggregate)) {
-            return false;
-        }
-
-        if (!areOptionalAttrsEqual(u32, self.multiExitDiscriminator, other.multiExitDiscriminator)) {
-            return false;
-        }
-
-        if (!areOptionalAttrsEqual(Aggregator, self.aggregator, other.aggregator)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    pub fn hash(self: Self, hasher: anytype) void {
-        std.hash.autoHash(hasher, self.origin.value);
-        self.asPath.value.hash(hasher);
-        std.hash.autoHash(hasher, self.nexthop.value);
-        std.hash.autoHash(hasher, self.localPref.value);
-        if (self.atomicAggregate) |v| {
-            std.hash.autoHash(hasher, v.value);
-        }
-        if (self.multiExitDiscriminator) |v| {
-            std.hash.autoHash(hasher, v.value);
-        }
-        if (self.aggregator) |agg| {
-            agg.value.hash(hasher);
+    pub fn clone(self: *@This(), allocator: Allocator) !@This() {
+        switch (self) {
+            .AsPath => |asPath| {
+                return .{ .AsPath = asPath.clone(allocator)};
+            },
+            .Origin,
+            .Nexthop,
+            .LocalPref,
+            .AtomicAggregate,
+            .MultiExitDiscriminator,
+            .Aggregator => { return self.*; }
         }
     }
 };
 
+
 pub const MessageContext = struct {
     peerType: ?sessions.Session.PeerType
+};
+
+pub const AttributeList = struct {
+    alloc: Allocator,
+    list: std.ArrayListUnmanaged(PathAttribute),
+
+    pub fn deinit(self: *@This()) void {
+        for (self.list.items) |*attr| {
+            attr.deinit();
+        }
+        self.list.deinit(self.alloc);
+    }
 };
 
 pub const UpdateMessage = struct {
@@ -467,12 +175,12 @@ pub const UpdateMessage = struct {
 
     withdrawnRoutes: []const Route,
     advertisedRoutes: []const Route,
-    pathAttributes: ?PathAttributes,
+    pathAttributes: AttributeList,
 
-    pub fn init(allocator: Allocator, withdrawnRoutes: []const Route, advertisedRoutes: []const Route, pathAttributes: ?PathAttributes) !Self {
+    pub fn init(allocator: Allocator, withdrawnRoutes: []const Route, advertisedRoutes: []const Route, pathAttributes: AttributeList) !Self {
         // If attributes is null, advertisedRoutes must be empty
-        std.debug.assert(pathAttributes != null or advertisedRoutes.len == 0);
-        std.debug.assert(pathAttributes == null or advertisedRoutes.len > 0);
+        std.debug.assert(pathAttributes.list.items.len > 0 or advertisedRoutes.len == 0);
+        std.debug.assert(pathAttributes.list.items.len == 0 or advertisedRoutes.len > 0);
 
         const wR = try allocator.alloc(Route, withdrawnRoutes.len);
         errdefer allocator.free(wR);
@@ -486,22 +194,15 @@ pub const UpdateMessage = struct {
             .allocator = allocator,
             .withdrawnRoutes = wR,
             .advertisedRoutes = aR,
-            .pathAttributes = attrs: {
-                if (pathAttributes) |attrs| {
-                    break :attrs try attrs.clone(allocator);
-                } else {
-                    break :attrs null;
-                }
-            },
+            .pathAttributes = pathAttributes,
         };
     }
 
     pub fn deinit(self: *const Self) void {
         self.allocator.free(self.withdrawnRoutes);
         self.allocator.free(self.advertisedRoutes);
-        if (self.pathAttributes) |attrs| {
-            attrs.deinit();
-        }
+        var attrs = self.pathAttributes;
+        attrs.deinit();
     }
 };
 
@@ -533,119 +234,3 @@ pub const BgpMessage = union(BgpMessageType) {
     }
 };
 
-test "PathAttributes hash and equal" {
-    const allocator = std.testing.allocator;
-
-    const as_path_seg = ASPathSegment{
-        .allocator = allocator,
-        .segType = .AS_Sequence,
-        .contents = try allocator.dupe(u16, &[_]u16{ 1, 2, 3 }),
-    };
-    defer as_path_seg.deinit();
-
-    const as_path = ASPath{
-        .allocator = allocator,
-        .segments = try allocator.dupe(ASPathSegment, &[_]ASPathSegment{try as_path_seg.clone(allocator)}),
-    };
-    defer as_path.deinit();
-
-    const attrs1 = PathAttributes{
-        .allocator = allocator,
-        .origin = .init(.IGP),
-        .asPath = .init(try as_path.clone(allocator)),
-        .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
-        .localPref = .init(100),
-        .atomicAggregate = .init(false),
-        .multiExitDiscriminator = .init(0),
-        .aggregator = .init(.{
-            .as = 65001,
-            .address = ip.IpV4Address.parse("2.2.2.2") catch unreachable,
-        }),
-    };
-    defer attrs1.deinit();
-
-    const attrs2 = try attrs1.clone(allocator);
-    defer attrs2.deinit();
-
-    try std.testing.expect(attrs1.equal(&attrs2));
-
-    var hasher1 = std.hash.Wyhash.init(0);
-    attrs1.hash(&hasher1);
-    const h1 = hasher1.final();
-
-    var hasher2 = std.hash.Wyhash.init(0);
-    attrs2.hash(&hasher2);
-    const h2 = hasher2.final();
-
-    try std.testing.expectEqual(h1, h2);
-
-    // Test differences
-    var attrs3 = try attrs1.clone(allocator);
-    defer attrs3.deinit();
-    attrs3.localPref.value = 200;
-    try std.testing.expect(!attrs1.equal(&attrs3));
-
-    var hasher3 = std.hash.Wyhash.init(0);
-    attrs3.hash(&hasher3);
-    try std.testing.expect(h1 != hasher3.final());
-
-    // Test ASPath difference
-    var attrs4 = try attrs1.clone(allocator);
-    defer attrs4.deinit();
-    attrs4.asPath.value.deinit();
-    const new_seg = ASPathSegment{
-        .allocator = allocator,
-        .segType = .AS_Sequence,
-        .contents = try allocator.dupe(u16, &[_]u16{ 1, 2, 4 }),
-    };
-    attrs4.asPath.value = ASPath{
-        .allocator = allocator,
-        .segments = try allocator.dupe(ASPathSegment, &[_]ASPathSegment{new_seg}),
-    };
-    try std.testing.expect(!attrs1.equal(&attrs4));
-
-    var hasher4 = std.hash.Wyhash.init(0);
-    attrs4.hash(&hasher4);
-    try std.testing.expect(h1 != hasher4.final());
-}
-
-test "ASPath.prependASN" {
-    const allocator = std.testing.allocator;
-
-    // 1. Test empty ASPath
-    var as_path = ASPath.createEmpty(allocator);
-    defer as_path.deinit();
-
-    try as_path.prependASN(100);
-    try std.testing.expectEqual(@as(usize, 1), as_path.segments.len);
-    try std.testing.expectEqual(ASPathSegmentType.AS_Sequence, as_path.segments[0].segType);
-    try std.testing.expectEqual(@as(usize, 1), as_path.segments[0].contents.len);
-    try std.testing.expectEqual(@as(u16, 100), as_path.segments[0].contents[0]);
-
-    // 2. Test prepending to existing AS_Sequence
-    try as_path.prependASN(200);
-    try std.testing.expectEqual(@as(usize, 1), as_path.segments.len);
-    try std.testing.expectEqual(ASPathSegmentType.AS_Sequence, as_path.segments[0].segType);
-    try std.testing.expectEqual(@as(usize, 2), as_path.segments[0].contents.len);
-    try std.testing.expectEqual(@as(u16, 200), as_path.segments[0].contents[0]);
-    try std.testing.expectEqual(@as(u16, 100), as_path.segments[0].contents[1]);
-
-    // 3. Test prepending to AS_Set (should create new AS_Sequence)
-    var as_set_path = ASPath{
-        .allocator = allocator,
-        .segments = try allocator.alloc(ASPathSegment, 1),
-    };
-    @constCast(as_set_path.segments)[0] = ASPathSegment{
-        .allocator = allocator,
-        .segType = .AS_Set,
-        .contents = try allocator.dupe(u16, &[_]u16{ 300, 400 }),
-    };
-    defer as_set_path.deinit();
-
-    try as_set_path.prependASN(500);
-    try std.testing.expectEqual(@as(usize, 2), as_set_path.segments.len);
-    try std.testing.expectEqual(ASPathSegmentType.AS_Sequence, as_set_path.segments[0].segType);
-    try std.testing.expectEqual(@as(usize, 1), as_set_path.segments[0].contents.len);
-    try std.testing.expectEqual(@as(u16, 500), as_set_path.segments[0].contents[0]);
-    try std.testing.expectEqual(ASPathSegmentType.AS_Set, as_set_path.segments[1].segType);
-}

--- a/src/messaging/model.zig
+++ b/src/messaging/model.zig
@@ -120,7 +120,7 @@ const PathAttribute = union(enum) {
 
 
     pub fn deinit(self: *@This()) void {
-        switch (self) {
+        switch (self.*) {
             .AsPath => |*asPath| {
                 asPath.value.deinit();
             },
@@ -149,11 +149,6 @@ const PathAttribute = union(enum) {
             .Aggregator => { return self.*; }
         }
     }
-};
-
-
-pub const MessageContext = struct {
-    peerType: ?sessions.Session.PeerType
 };
 
 pub const AttributeList = struct {

--- a/src/messaging/model.zig
+++ b/src/messaging/model.zig
@@ -98,7 +98,7 @@ pub const NotificationMessage = struct {
     }
 };
 
-const PathAttribute = union(enum) {
+pub const PathAttribute = union(enum) {
     Origin: OriginAttr,
     AsPath: AsPathAttr,
     Nexthop: NexthopAttr,
@@ -137,16 +137,24 @@ const PathAttribute = union(enum) {
     }
 
     pub fn clone(self: *@This(), allocator: Allocator) !@This() {
-        switch (self) {
+        switch (self.*) {
             .AsPath => |asPath| {
-                return .{ .AsPath = asPath.clone(allocator)};
+                var tmp: AsPathAttr = asPath;
+                tmp.value = try asPath.value.clone(allocator);
+                return .{ .AsPath = tmp };
             },
             .Origin,
             .Nexthop,
             .LocalPref,
             .AtomicAggregate,
             .MultiExitDiscriminator,
-            .Aggregator => { return self.*; }
+            .Aggregator => { return self.*; },
+            .Unknown => |unknown| {
+                var tmp: UnknownAttr = unknown;
+                tmp.value.value = try allocator.dupe(u8, unknown.value.value);
+                tmp.value.allocator = allocator;
+                return .{ .Unknown = tmp };
+            },
         }
     }
 };

--- a/src/messaging/model.zig
+++ b/src/messaging/model.zig
@@ -185,13 +185,11 @@ pub const UpdateMessage = struct {
         std.debug.assert(pathAttributes.list.items.len > 0 or advertisedRoutes.len == 0);
         std.debug.assert(pathAttributes.list.items.len == 0 or advertisedRoutes.len > 0);
 
-        const wR = try allocator.alloc(Route, withdrawnRoutes.len);
+        const wR = try allocator.dupe(Route, withdrawnRoutes);
         errdefer allocator.free(wR);
-        std.mem.copyForwards(Route, wR, withdrawnRoutes);
 
-        const aR = try allocator.alloc(Route, advertisedRoutes.len);
+        const aR = try allocator.dupe(Route, advertisedRoutes);
         errdefer allocator.free(aR);
-        std.mem.copyForwards(Route, aR, advertisedRoutes);
 
         return Self{
             .allocator = allocator,
@@ -201,11 +199,10 @@ pub const UpdateMessage = struct {
         };
     }
 
-    pub fn deinit(self: *const Self) void {
+    pub fn deinit(self: *Self) void {
         self.allocator.free(self.withdrawnRoutes);
         self.allocator.free(self.advertisedRoutes);
-        var attrs = self.pathAttributes;
-        attrs.deinit();
+        self.pathAttributes.deinit();
     }
 };
 
@@ -228,10 +225,10 @@ pub const BgpMessage = union(BgpMessageType) {
     NOTIFICATION: NotificationMessage,
     KEEPALIVE: KeepAliveMessage,
 
-    pub fn deinit(self: Self) void {
-        switch (self) {
-            .UPDATE => |msg| msg.deinit(),
-            .NOTIFICATION => |msg| msg.deinit(),
+    pub fn deinit(self: *Self) void {
+        switch (self.*) {
+            .UPDATE => |*msg| msg.deinit(),
+            .NOTIFICATION => |*msg| msg.deinit(),
             else => {},
         }
     }

--- a/src/messaging/parsing/message_reader.zig
+++ b/src/messaging/parsing/message_reader.zig
@@ -20,18 +20,6 @@ pub const MessageReader = struct {
 
     pub fn deinit(_: *Self) void {}
 
-    pub fn deInitMessage(_: *Self, m: model.BgpMessage) void {
-        switch (m) {
-            .NOTIFICATION => |msg| {
-                msg.deinit();
-            },
-            .UPDATE => |msg| {
-                msg.deinit();
-            },
-            else => {}
-        }
-    }
-
     pub fn readMessage(self: *Self, stream: *std.Io.Reader) !model.BgpMessage {
         const messageHeader = try headerReader.readHeader(stream);
 

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -351,65 +351,17 @@ test "readRoutes()" {
     try testing.expectEqualSlices(Route, expectedRoutes[0..], routes.items);
 }
 
-test "readUpdateMessage()" {
+test "readUpdateMessage() - Minimal (Withdrawn only)" {
     const messageBuffer = [_]u8{
-        //Withdrawn length
-        0,
-        3,
-        // R3
-        // Length
-        12,
-        // Route
-        192,
-        0b10111111,
-        // Attributes Length
-        0,
-        20,
-        // Origin
-        0x40,
-        1,
-        1,
-        0,
-        // ASPath
-        0x40,
-        2,
-        6,
-        2,
-        2,
-        0,
-        100,
-        0,
-        200,
-        // NextHop
-        0x40,
-        3,
-        4,
-        192,
-        168,
-        0,
-        1,
-        // Advertised
-        // R1
-        // Length
-        32,
-        // Route
-        192,
-        168,
-        0,
-        42,
-        // R2
-        // Length
-        16,
-        // Route
-        192,
-        168,
+        0, 3, // Withdrawn length: 3
+        12, 192, 0b10111111, // R3: 192.176.0.0/12 (roughly)
+        0, 0, // Attributes length: 0
     };
 
-    var stream = std.io.fixedBufferStream(messageBuffer[0..]);
-
+    var stream = std.io.fixedBufferStream(&messageBuffer);
     var readBuffer: [1024]u8 = undefined;
     var reader = stream.reader().adaptToNewApi(&readBuffer);
-    var updateReader = Self{
+    var updateReader = UpdateMsgParser{
         .allocator = testing.allocator,
         .reader = &reader.new_interface,
     };
@@ -417,23 +369,9 @@ test "readUpdateMessage()" {
     defer message.deinit();
 
     try testing.expectEqual(stream.getPos(), messageBuffer.len);
-
-    try testing.expectEqualSlices(Route, &[_]Route{Route{ .prefixLength = 12, .prefixData = [_]u8{ 192, 0b10110000, 0, 0 } }}, message.withdrawnRoutes);
-    try testing.expectEqualSlices(Route, &[_]Route{
-        Route{ .prefixLength = 32, .prefixData = [_]u8{ 192, 168, 0, 42 } },
-        Route{ .prefixLength = 16, .prefixData = [_]u8{ 192, 168, 0, 0 } },
-    }, message.advertisedRoutes);
-    // Verify attribute values
-    const attrs = message.pathAttributes.list.items;
-    try testing.expectEqual(@as(usize, 3), attrs.len);
-    
-    try testing.expectEqual(ribModel.Origin.IGP, attrs[0].Origin.value);
-
-    try testing.expectEqual(@as(usize, 1), attrs[1].AsPath.value.segments.len);
-    try testing.expectEqual(ribModel.ASPathSegmentType.AS_Sequence, attrs[1].AsPath.value.segments[0].segType);
-    try testing.expectEqualSlices(u16, &[_]u16{ 100, 200 }, attrs[1].AsPath.value.segments[0].contents);
-
-    try testing.expect(attrs[2].Nexthop.value.equals(ip.IpV4Address.parse("192.168.0.1") catch unreachable));
+    try testing.expectEqual(@as(usize, 1), message.withdrawnRoutes.len);
+    try testing.expectEqual(@as(usize, 0), message.advertisedRoutes.len);
+    try testing.expectEqual(@as(usize, 0), message.pathAttributes.list.items.len);
 }
 
 fn testReadAsPath(asPathBuffer: []const u8, expectedASPath: ribModel.ASPath) !void {
@@ -501,57 +439,56 @@ test "readAsPath()" {
     try testReadAsPath(&buffer2, expected2);
 }
 
-test "readNextHop()" {
-    const buffer = [_]u8{ 192, 168, 0, 1 };
-    var stream = std.io.fixedBufferStream(&buffer);
-    var readBuffer: [1024]u8 = undefined;
-    var reader = stream.reader().adaptToNewApi(&readBuffer);
-    var updateReader = Self{
-        .allocator = testing.allocator,
-        .reader = &reader.new_interface,
-    };
+test "readUpdateMessage() - All Attributes" {
+    const unknownDataShort = [_]u8{ 1, 2, 3 };
+    var unknownDataLong: [300]u8 = undefined;
+    @memset(&unknownDataLong, 0xAA);
 
-    const actualNextHop = try updateReader.readNextHop();
-    try testing.expect(actualNextHop.equals(ip.IpV4Address.parse("192.168.0.1") catch unreachable));
-}
-
-test "readAttributes compound test" {
-    const attributesBuffer = [_]u8{
-        // Origin (Well-known mandatory)
-        0x40, // Flags (Transitive)
-        1,    // Type
-        1,    // Length
-        0,    // Value (IGP)
+    const messageBuffer = blk: {
+        var list = std.array_list.Managed(u8).init(testing.allocator);
+        // Withdrawn (1 route: 10.0.0.0/24 -> 4 bytes)
+        try list.appendSlice(&[_]u8{ 0, 4, 24, 10, 0, 0 });
         
-        // LocalPref
-        0x40, // Flags
-        5,    // Type
-        4,    // Length
-        0, 0, 0, 200, // Value
+        // Attrs
+        // We'll calculate total length later. Let's start with a placeholder.
+        const attrLenPlaceholderIdx = list.items.len;
+        try list.appendSlice(&[_]u8{ 0, 0 });
 
-        // Unknown Attribute (Mocked)
-        0x00, // Flags (Non-transitive, Optional as per BGP rules it should be ignored if unknown)
-        99,   // Type (Unknown)
-        5,    // Length
-        1, 2, 3, 4, 5, // Data (to be ignored)
+        const attrStartIdx = list.items.len;
 
-        // ASPath (Well-known mandatory)
-        0x40, // Flags (Transitive)
-        2,    // Type
-        6,    // Length
-        2,    // AS_Sequence
-        2,    // Length
-        0, 100,
-        0, 200,
+        // -- Origin (Flags:0x40, Type:1, Len:1, Val:0)
+        try list.appendSlice(&[_]u8{ 0x40, 1, 1, 0 });
+        // -- AsPath (Flags:0x40, Type:2, Len:6, Val: [Seq, 2 ASNs, 100, 200])
+        try list.appendSlice(&[_]u8{ 0x40, 2, 6, 2, 2, 0, 100, 0, 200 });
+        // -- NextHop (Flags:0x40, Type:3, Len:4, Val: 1.2.3.4)
+        try list.appendSlice(&[_]u8{ 0x40, 3, 4, 1, 2, 3, 4 });
+        // -- MED (Flags:0x80, Type:4, Len:4, Val: 1234)
+        try list.appendSlice(&[_]u8{ 0x80, 4, 4, 0, 0, 4, 210 });
+        // -- LocalPref (Flags:0x40, Type:5, Len:4, Val: 100)
+        try list.appendSlice(&[_]u8{ 0x40, 5, 4, 0, 0, 0, 100 });
+        // -- AtomicAggregate (Flags:0x40, Type:6, Len:0)
+        try list.appendSlice(&[_]u8{ 0x40, 6, 0 });
+        // -- Aggregator (Flags:0xC0, Type:7, Len:6, Val: AS 65001, 1.2.3.4)
+        try list.appendSlice(&[_]u8{ 0xC0, 7, 6, 0xFD, 0xE9, 1, 2, 3, 4 });
+        // -- Unknown Short (Flags:0x80, Type:100, Len:3)
+        try list.appendSlice(&[_]u8{ 0x80, 100, 3 });
+        try list.appendSlice(&unknownDataShort);
+        // -- Unknown Long (Flags:0x90, Type:101, Len:300)
+        try list.appendSlice(&[_]u8{ 0x90, 101, 1, 44 });
+        try list.appendSlice(&unknownDataLong);
 
-        // NextHop (Well-known mandatory)
-        0x40, // Flags (Transitive)
-        3,    // Type
-        4,    // Length
-        192, 168, 0, 1,
+        const attrEndIdx = list.items.len;
+        const totalAttrLen: u16 = @intCast(attrEndIdx - attrStartIdx);
+        std.mem.writeInt(u16, list.items[attrLenPlaceholderIdx..][0..2], totalAttrLen, .big);
+
+        // Advertised (1 route: 192.168.1.0/24 -> 4 bytes)
+        try list.appendSlice(&[_]u8{ 24, 192, 168, 1 });
+
+        break :blk list;
     };
+    defer messageBuffer.deinit();
 
-    var stream = std.io.fixedBufferStream(&attributesBuffer);
+    var stream = std.io.fixedBufferStream(messageBuffer.items);
     var readBuffer: [1024]u8 = undefined;
     var reader = stream.reader().adaptToNewApi(&readBuffer);
     var updateReader = UpdateMsgParser{
@@ -559,40 +496,39 @@ test "readAttributes compound test" {
         .reader = &reader.new_interface,
     };
 
-    var attrs = try updateReader.readAttributes(@intCast(attributesBuffer.len));
-    defer attrs.deinit();
+    var message = try updateReader.readUpdateMessage(@intCast(messageBuffer.items.len));
+    defer message.deinit();
 
-    // Verify attributes were parsed correctly despite the unknown attribute
-    const parsedAttrs = attrs.list.items;
-    try testing.expectEqual(@as(usize, 5), parsedAttrs.len);
+    // Verify Routes
+    try testing.expectEqual(@as(usize, 1), message.withdrawnRoutes.len);
+    try testing.expectEqual(@as(u8, 24), message.withdrawnRoutes[0].prefixLength);
+    try testing.expectEqualSlices(u8, &[_]u8{ 10, 0, 0, 0 }, &message.withdrawnRoutes[0].prefixData);
 
-    try testing.expectEqual(ribModel.Origin.IGP, parsedAttrs[0].Origin.value);
-    
-    try testing.expectEqual(@as(u32, 200), parsedAttrs[1].LocalPref.value);
-    
-    try testing.expectEqual(@as(u8, 99), parsedAttrs[2].Unknown.value.typeCode);
-    try testing.expectEqualSlices(u8, &[_]u8{ 1, 2, 3, 4, 5 }, parsedAttrs[2].Unknown.value.value);
-    
-    try testing.expectEqual(@as(usize, 1), parsedAttrs[3].AsPath.value.segments.len);
-    try testing.expectEqual(ribModel.ASPathSegmentType.AS_Sequence, parsedAttrs[3].AsPath.value.segments[0].segType);
-    try testing.expectEqualSlices(u16, &[_]u16{ 100, 200 }, parsedAttrs[3].AsPath.value.segments[0].contents);
-    
-    try testing.expect(parsedAttrs[4].Nexthop.value.equals(ip.IpV4Address.parse("192.168.0.1") catch unreachable));
-    
-    // Ensure we read the entire buffer
-    try testing.expectEqual(attributesBuffer.len, stream.getPos());
-}
+    try testing.expectEqual(@as(usize, 1), message.advertisedRoutes.len);
+    try testing.expectEqual(@as(u8, 24), message.advertisedRoutes[0].prefixLength);
+    try testing.expectEqualSlices(u8, &[_]u8{ 192, 168, 1, 0 }, &message.advertisedRoutes[0].prefixData);
 
-test "readLocalPref()" {
-    const buffer = [_]u8{ 0, 0, 0, 100 };
-    var stream = std.io.fixedBufferStream(&buffer);
-    var readBuffer: [1024]u8 = undefined;
-    var reader = stream.reader().adaptToNewApi(&readBuffer);
-    var updateReader = Self{
-        .allocator = testing.allocator,
-        .reader = &reader.new_interface,
-    };
+    // Verify Attributes
+    const attrs = message.pathAttributes.list.items;
+    try testing.expectEqual(@as(usize, 9), attrs.len);
 
-    const actualLocalPref = try updateReader.readLocalPref();
-    try testing.expectEqual(@as(u32, 100), actualLocalPref);
+    try testing.expectEqual(ribModel.Origin.IGP, attrs[0].Origin.value);
+    
+    try testing.expectEqual(@as(usize, 1), attrs[1].AsPath.value.segments.len);
+    try testing.expectEqual(ribModel.ASPathSegmentType.AS_Sequence, attrs[1].AsPath.value.segments[0].segType);
+    try testing.expectEqualSlices(u16, &[_]u16{ 100, 200 }, attrs[1].AsPath.value.segments[0].contents);
+
+    try testing.expect(attrs[2].Nexthop.value.equals(ip.IpV4Address.parse("1.2.3.4") catch unreachable));
+    try testing.expectEqual(@as(u32, 1234), attrs[3].MultiExitDiscriminator.value);
+    try testing.expectEqual(@as(u32, 100), attrs[4].LocalPref.value);
+    try testing.expect(attrs[5].AtomicAggregate.value);
+    try testing.expectEqual(@as(u16, 65001), attrs[6].Aggregator.value.as);
+    try testing.expect(attrs[6].Aggregator.value.address.equals(ip.IpV4Address.init(1, 2, 3, 4)));
+
+    try testing.expectEqual(@as(u8, 100), attrs[7].Unknown.value.typeCode);
+    try testing.expectEqualSlices(u8, &unknownDataShort, attrs[7].Unknown.value.value);
+
+    try testing.expectEqual(@as(u8, 101), attrs[8].Unknown.value.typeCode);
+    try testing.expectEqualSlices(u8, &unknownDataLong, attrs[8].Unknown.value.value);
+    try testing.expect((attrs[8].Unknown.flags & ribModel.ATTR_EXTENDED_LENGTH_FLAG) != 0);
 }

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -123,6 +123,15 @@ fn readLocalPref(self: *Self) !u32 {
     return try self.reader.takeInt(u32, .big);
 }
 
+fn readAggregator(self: *Self) !ribModel.Aggregator {
+    var agg: ribModel.Aggregator = .{
+        .as = try self.reader.takeInt(u16, .big),
+        .address = undefined
+    };
+    try self.reader.readSliceAll(agg.address.address);
+    return agg;
+}
+
 fn readUnknownAttributeValue(self: *Self, len: u16) ![]u8 {
     const buffer = try self.allocator.alloc(u8, len);
     errdefer self.allocator.free(buffer);
@@ -174,6 +183,12 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
                     .value = try self.readNextHop(),
                 } };
             },
+            4 => {
+                break :attr .{ .MultiExitDiscriminator = .{
+                    .flags = attributeFlags,
+                    .value = try self.reader.takeInt(u32, .big),
+                } };
+            },
             5 => {
                 // FIXME make sure localPref flags are properly set
                 std.debug.assert(attributeLength == 4);
@@ -181,6 +196,18 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
                     .flags = attributeFlags,
                     .value = try self.readLocalPref(),
                 } };
+            },
+            6 => {
+                break :attr .{ .AtomicAggregate = .{
+                    .flags = attributeFlags,
+                    .value = true
+                }};
+            },
+            7 => {
+                break :attr .{ .Aggregator = .{
+                    .flags = attributeFlags,
+                    .value = try self.readAggregator(),
+                }};
             },
             else => {
                 // Ignore unknown attribute

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -78,6 +78,11 @@ fn readOrigin(self: *Self) !ribModel.Origin {
 fn readAsPath(self: *Self, bytesLength: u16) !ribModel.ASPath {
     var pathSegments: std.ArrayList(ribModel.ASPathSegment) = .empty;
     defer pathSegments.deinit(self.allocator);
+    errdefer {
+        for (pathSegments.items) |*seg| {
+            seg.deinit();
+        }
+    }
 
     var currentRead: usize = 0;
     while (currentRead < bytesLength) {
@@ -89,12 +94,11 @@ fn readAsPath(self: *Self, bytesLength: u16) !ribModel.ASPath {
         for (0..segmentLength) |i| {
             segmentContents[i] = try self.reader.takeInt(u16, .big);
         }
-        const segment = try pathSegments.addOne(self.allocator);
-        segment.* = .{
+        try pathSegments.append(self.allocator, .{
             .allocator = self.allocator,
             .segType = segmentType,
             .contents = segmentContents,
-        };
+        });
 
         currentRead += (2 + (segmentLength * 2));
     }
@@ -133,6 +137,12 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
         .alloc = self.allocator,
         .list = .empty
     };
+    errdefer {
+        for (attributes.list.items) |*attr| {
+            attr.deinit();
+        }
+        attributes.list.deinit(attributes.alloc);
+    }
 
     var bytesToRead: i32 = @intCast(attributesLength);
     while (bytesToRead > 0) {
@@ -142,26 +152,24 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
         const extendedLength: bool = (attributeFlags & ribModel.ATTR_EXTENDED_LENGTH_FLAG) > 0;
         const attributeLength: u16 = if (extendedLength) try self.reader.takeInt(u16, .big) else @intCast(try self.reader.takeInt(u8, .big));
 
-        const attribute = try attributes.list.addOne(attributes.alloc);
-
         // TODO: Unrecognized non-transitive optional attributes MUST be
         // quietly ignored and not passed along to other BGP peers.
-        switch (attributeType) {
+        const attribute: PathAttribute = attr: switch (attributeType) {
             1 => {
-                attribute.* = .{ .Origin = .{
+                break :attr .{ .Origin = .{
                     .flags = attributeFlags,
                     .value = try self.readOrigin(),
                 } };
             },
             2 => {
-                attribute.* = .{ .AsPath = .{
+                break :attr .{ .AsPath = .{
                     .flags = attributeFlags,
                     .value = try self.readAsPath(attributeLength),
                 } };
             },
             3 => {
                 std.debug.assert(attributeLength == 4);
-                attribute.* = .{ .Nexthop = .{
+                break :attr .{ .Nexthop = .{
                     .flags = attributeFlags,
                     .value = try self.readNextHop(),
                 } };
@@ -169,14 +177,14 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
             5 => {
                 // FIXME make sure localPref flags are properly set
                 std.debug.assert(attributeLength == 4);
-                attribute.* = .{ .LocalPref = .{
+                break :attr .{ .LocalPref = .{
                     .flags = attributeFlags,
                     .value = try self.readLocalPref(),
                 } };
             },
             else => {
                 // Ignore unknown attribute
-                attribute.* = .{ .Unknown = .{
+                break :attr .{ .Unknown = .{
                     .flags = attributeFlags,
                     .value = .{
                         .allocator = self.allocator,
@@ -185,7 +193,9 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
                     },
                 } };
             },
-        }
+        };
+
+        try attributes.list.append(self.allocator, attribute);
 
         bytesToRead -= 2; // For attributeFlags and attributeType
         bytesToRead -= if (extendedLength) 2 else 1; // For attributeLength field itself

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -231,7 +231,7 @@ pub fn readUpdateMessage(self: *Self, messageLength: u16) !messageModel.UpdateMe
         };
         return .init(self.allocator, withdrawnRoutes.items, self.allocator.alloc(Route, 0) catch unreachable, attrs);
     } else {
-        const routeAttributes = try self.readAttributes(attributesLength);
+        var routeAttributes = try self.readAttributes(attributesLength);
         errdefer routeAttributes.deinit();
 
         const advertisedRoutes = try self.readRoutes(advertisedLength);

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -134,10 +134,6 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
         .list = .empty
     };
 
-    //var originRead: bool = false;
-    //var asPathRead: bool = false;
-    //var nextHopRead: bool = false;
-
     var bytesToRead: i32 = @intCast(attributesLength);
     while (bytesToRead > 0) {
         const attributeFlags = try self.reader.takeInt(u8, .big);
@@ -188,7 +184,6 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
                         .value = try self.readUnknownAttributeValue(attributeLength),
                     },
                 } };
-                try self.reader.discardAll(attributeLength);
             },
         }
 
@@ -196,16 +191,6 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
         bytesToRead -= if (extendedLength) 2 else 1; // For attributeLength field itself
         bytesToRead -= attributeLength; // For the attribute value
     }
-
-    //if (!originRead) {
-    //    return UpdateParsingError.MissingOriginAttribute;
-    //}
-    //if (!asPathRead) {
-    //    return UpdateParsingError.MissingASPathAttribute;
-    //}
-    //if (!nextHopRead) {
-    //    return UpdateParsingError.MissingNexthopAttribute;
-    //}
 
     if (bytesToRead != 0) {
         return UpdateParsingError.AttributesLengthInconsistent;
@@ -537,7 +522,7 @@ test "readAttributes compound test" {
         .reader = &reader.new_interface,
     };
 
-    const attrs = try updateReader.readAttributes(@intCast(attributesBuffer.len));
+    var attrs = try updateReader.readAttributes(@intCast(attributesBuffer.len));
     defer attrs.deinit();
 
     // Verify attributes were parsed correctly despite the unknown attribute

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -147,10 +147,7 @@ fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
         .list = .empty
     };
     errdefer {
-        for (attributes.list.items) |*attr| {
-            attr.deinit();
-        }
-        attributes.list.deinit(attributes.alloc);
+        attributes.deinit();
     }
 
     var bytesToRead: i32 = @intCast(attributesLength);

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -128,7 +128,7 @@ fn readAggregator(self: *Self) !ribModel.Aggregator {
         .as = try self.reader.takeInt(u16, .big),
         .address = undefined
     };
-    try self.reader.readSliceAll(agg.address.address);
+    try self.reader.readSliceAll(&agg.address.address);
     return agg;
 }
 

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -1,9 +1,11 @@
 const std = @import("std");
 const ip = @import("ip");
-const model = @import("../model.zig");
+const ribModel = @import("../../rib/model.zig");
+const messageModel = @import("../model.zig");
 
-const Route = model.Route;
-const PathAttributes = model.PathAttributes;
+const Route = ribModel.Route;
+const PathAttribute = messageModel.PathAttribute;
+const AttributeList = messageModel.AttributeList;
 
 const UpdateParsingError = error{ 
 RoutesLengthInconsistent, 
@@ -67,20 +69,20 @@ fn readRoutes(self: *Self, routesLength: u16) !std.array_list.Managed(Route) {
     return routesList;
 }
 
-fn readOrigin(self: *Self) !model.Origin {
+fn readOrigin(self: *Self) !ribModel.Origin {
     // TODO: origin value validation
-    const origin: model.Origin = @enumFromInt(try self.reader.takeInt(u8, .big));
+    const origin: ribModel.Origin = @enumFromInt(try self.reader.takeInt(u8, .big));
     return origin;
 }
 
-fn readAsPath(self: *Self, bytesLength: u16) !model.ASPath {
-    var pathSegments: std.ArrayList(model.ASPathSegment) = .empty;
+fn readAsPath(self: *Self, bytesLength: u16) !ribModel.ASPath {
+    var pathSegments: std.ArrayList(ribModel.ASPathSegment) = .empty;
     defer pathSegments.deinit(self.allocator);
 
     var currentRead: usize = 0;
     while (currentRead < bytesLength) {
         // TODO: segment type value validation
-        const segmentType: model.ASPathSegmentType = @enumFromInt(try self.reader.takeInt(u8, .big));
+        const segmentType: ribModel.ASPathSegmentType = @enumFromInt(try self.reader.takeInt(u8, .big));
         const segmentLength: usize = @intCast(try self.reader.takeInt(u8, .big));
 
         const segmentContents = try self.allocator.alloc(u16, segmentLength);
@@ -103,7 +105,7 @@ fn readAsPath(self: *Self, bytesLength: u16) !model.ASPath {
 
     return .{
         .allocator = self.allocator,
-        .segments = try self.allocator.dupe(model.ASPathSegment, pathSegments.items),
+        .segments = try self.allocator.dupe(ribModel.ASPathSegment, pathSegments.items),
     };
 }
 
@@ -117,49 +119,75 @@ fn readLocalPref(self: *Self) !u32 {
     return try self.reader.takeInt(u32, .big);
 }
 
-fn readAttributes(self: *Self, attributesLength: u16) !PathAttributes {
-    var attributes: PathAttributes = .empty;
-    attributes.allocator = self.allocator;
+fn readUnknownAttributeValue(self: *Self, len: u16) ![]u8 {
+    const buffer = try self.allocator.alloc(u8, len);
+    errdefer self.allocator.free(buffer);
 
-    // Set local pref to the default value
-    attributes.localPref.flags = 0;
-    attributes.localPref.value = 100;
+    try self.reader.readSliceAll(buffer);
 
-    var originRead: bool = false;
-    var asPathRead: bool = false;
-    var nextHopRead: bool = false;
+    return buffer;
+}
+
+fn readAttributes(self: *Self, attributesLength: u16) !AttributeList {
+    var attributes: AttributeList = .{
+        .alloc = self.allocator,
+        .list = .empty
+    };
+
+    //var originRead: bool = false;
+    //var asPathRead: bool = false;
+    //var nextHopRead: bool = false;
 
     var bytesToRead: i32 = @intCast(attributesLength);
     while (bytesToRead > 0) {
         const attributeFlags = try self.reader.takeInt(u8, .big);
         const attributeType = try self.reader.takeInt(u8, .big);
 
-        const extendedLength: bool = (attributeFlags & model.ATTR_EXTENDED_LENGTH_FLAG) > 0;
+        const extendedLength: bool = (attributeFlags & ribModel.ATTR_EXTENDED_LENGTH_FLAG) > 0;
         const attributeLength: u16 = if (extendedLength) try self.reader.takeInt(u16, .big) else @intCast(try self.reader.takeInt(u8, .big));
+
+        const attribute = try attributes.list.addOne(attributes.alloc);
 
         // TODO: Unrecognized non-transitive optional attributes MUST be
         // quietly ignored and not passed along to other BGP peers.
         switch (attributeType) {
             1 => {
-                attributes.origin = .{ .flags = attributeFlags, .value = try self.readOrigin() };
-                originRead = true;
+                attribute.* = .{ .Origin = .{
+                    .flags = attributeFlags,
+                    .value = try self.readOrigin(),
+                } };
             },
             2 => {
-                attributes.asPath = .{ .flags = attributeFlags, .value = try self.readAsPath(attributeLength) };
-                asPathRead = true;
+                attribute.* = .{ .AsPath = .{
+                    .flags = attributeFlags,
+                    .value = try self.readAsPath(attributeLength),
+                } };
             },
             3 => {
                 std.debug.assert(attributeLength == 4);
-                attributes.nexthop = .{ .flags = attributeFlags, .value = try self.readNextHop() };
-                nextHopRead = true;
+                attribute.* = .{ .Nexthop = .{
+                    .flags = attributeFlags,
+                    .value = try self.readNextHop(),
+                } };
             },
             5 => {
                 // FIXME make sure localPref flags are properly set
                 std.debug.assert(attributeLength == 4);
-                attributes.localPref = .{ .flags = attributeFlags, .value = try self.readLocalPref() };
+                attribute.* = .{ .LocalPref = .{
+                    .flags = attributeFlags,
+                    .value = try self.readLocalPref(),
+                } };
             },
             else => {
                 // Ignore unknown attribute
+                attribute.* = .{ .Unknown = .{
+                    .flags = attributeFlags,
+                    .value = .{
+                        .allocator = self.allocator,
+                        .typeCode = attributeType,
+                        .value = try self.readUnknownAttributeValue(attributeLength),
+                    },
+                } };
                 try self.reader.discardAll(attributeLength);
             },
         }
@@ -169,15 +197,15 @@ fn readAttributes(self: *Self, attributesLength: u16) !PathAttributes {
         bytesToRead -= attributeLength; // For the attribute value
     }
 
-    if (!originRead) {
-        return UpdateParsingError.MissingOriginAttribute;
-    }
-    if (!asPathRead) {
-        return UpdateParsingError.MissingASPathAttribute;
-    }
-    if (!nextHopRead) {
-        return UpdateParsingError.MissingNexthopAttribute;
-    }
+    //if (!originRead) {
+    //    return UpdateParsingError.MissingOriginAttribute;
+    //}
+    //if (!asPathRead) {
+    //    return UpdateParsingError.MissingASPathAttribute;
+    //}
+    //if (!nextHopRead) {
+    //    return UpdateParsingError.MissingNexthopAttribute;
+    //}
 
     if (bytesToRead != 0) {
         return UpdateParsingError.AttributesLengthInconsistent;
@@ -186,7 +214,7 @@ fn readAttributes(self: *Self, attributesLength: u16) !PathAttributes {
     return attributes;
 }
 
-pub fn readUpdateMessage(self: *Self, messageLength: u16) !model.UpdateMessage {
+pub fn readUpdateMessage(self: *Self, messageLength: u16) !messageModel.UpdateMessage {
     const withdrawnLength = try self.reader.takeInt(u16, .big);
     const withdrawnRoutes = try self.readRoutes(withdrawnLength);
     defer withdrawnRoutes.deinit();
@@ -197,10 +225,14 @@ pub fn readUpdateMessage(self: *Self, messageLength: u16) !model.UpdateMessage {
         if (advertisedLength != 0) {
             return error.AdvertisedRoutesWithoutAttrs;
         }
-        return .init(self.allocator, withdrawnRoutes.items, self.allocator.alloc(Route, 0) catch unreachable, null);
+        const attrs: AttributeList = .{
+            .alloc = self.allocator,
+            .list = .empty
+        };
+        return .init(self.allocator, withdrawnRoutes.items, self.allocator.alloc(Route, 0) catch unreachable, attrs);
     } else {
         const routeAttributes = try self.readAttributes(attributesLength);
-        defer routeAttributes.deinit();
+        errdefer routeAttributes.deinit();
 
         const advertisedRoutes = try self.readRoutes(advertisedLength);
         defer advertisedRoutes.deinit();
@@ -370,18 +402,19 @@ test "readUpdateMessage()" {
         Route{ .prefixLength = 16, .prefixData = [_]u8{ 192, 168, 0, 0 } },
     }, message.advertisedRoutes);
     // Verify attribute values
-    try testing.expect(message.pathAttributes != null);
-    const attrs = message.pathAttributes.?;
-    try testing.expectEqual(model.Origin.IGP, attrs.origin.value);
+    const attrs = message.pathAttributes.list.items;
+    try testing.expectEqual(@as(usize, 3), attrs.len);
+    
+    try testing.expectEqual(ribModel.Origin.IGP, attrs[0].Origin.value);
 
-    try testing.expectEqual(@as(usize, 1), attrs.asPath.value.segments.len);
-    try testing.expectEqual(model.ASPathSegmentType.AS_Sequence, attrs.asPath.value.segments[0].segType);
-    try testing.expectEqualSlices(u16, &[_]u16{ 100, 200 }, attrs.asPath.value.segments[0].contents);
+    try testing.expectEqual(@as(usize, 1), attrs[1].AsPath.value.segments.len);
+    try testing.expectEqual(ribModel.ASPathSegmentType.AS_Sequence, attrs[1].AsPath.value.segments[0].segType);
+    try testing.expectEqualSlices(u16, &[_]u16{ 100, 200 }, attrs[1].AsPath.value.segments[0].contents);
 
-    try testing.expect(attrs.nexthop.value.equals(ip.IpV4Address.parse("192.168.0.1") catch unreachable));
+    try testing.expect(attrs[2].Nexthop.value.equals(ip.IpV4Address.parse("192.168.0.1") catch unreachable));
 }
 
-fn testReadAsPath(asPathBuffer: []const u8, expectedASPath: model.ASPath) !void {
+fn testReadAsPath(asPathBuffer: []const u8, expectedASPath: ribModel.ASPath) !void {
     var stream = std.io.fixedBufferStream(asPathBuffer[0..]);
     var readBuffer: [1024]u8 = undefined;
     var reader = stream.reader().adaptToNewApi(&readBuffer);
@@ -404,13 +437,13 @@ test "readAsPath()" {
         0, 100, // ASN 100
         0, 200, // ASN 200
     };
-    const segments1 = try testing.allocator.alloc(model.ASPathSegment, 1);
+    const segments1 = try testing.allocator.alloc(ribModel.ASPathSegment, 1);
     segments1[0] = .{
         .allocator = testing.allocator,
         .segType = .AS_Sequence,
         .contents = try testing.allocator.dupe(u16, &[_]u16{ 100, 200 }),
     };
-    const expected1 = model.ASPath{
+    const expected1 = ribModel.ASPath{
         .allocator = testing.allocator,
         .segments = segments1,
     };
@@ -427,7 +460,7 @@ test "readAsPath()" {
         0, 200, // ASN 200
         0, 201, // ASN 201
     };
-    const segments2 = try testing.allocator.alloc(model.ASPathSegment, 2);
+    const segments2 = try testing.allocator.alloc(ribModel.ASPathSegment, 2);
     segments2[0] = .{
         .allocator = testing.allocator,
         .segType = .AS_Sequence,
@@ -438,7 +471,7 @@ test "readAsPath()" {
         .segType = .AS_Set,
         .contents = try testing.allocator.dupe(u16, &[_]u16{ 200, 201 }),
     };
-    const expected2 = model.ASPath{
+    const expected2 = ribModel.ASPath{
         .allocator = testing.allocator,
         .segments = segments2,
     };
@@ -508,12 +541,21 @@ test "readAttributes compound test" {
     defer attrs.deinit();
 
     // Verify attributes were parsed correctly despite the unknown attribute
-    try testing.expectEqual(model.Origin.IGP, attrs.origin.value);
-    try testing.expectEqual(@as(u32, 200), attrs.localPref.value);
-    try testing.expectEqual(@as(usize, 1), attrs.asPath.value.segments.len);
-    try testing.expectEqual(model.ASPathSegmentType.AS_Sequence, attrs.asPath.value.segments[0].segType);
-    try testing.expectEqualSlices(u16, &[_]u16{ 100, 200 }, attrs.asPath.value.segments[0].contents);
-    try testing.expect(attrs.nexthop.value.equals(ip.IpV4Address.parse("192.168.0.1") catch unreachable));
+    const parsedAttrs = attrs.list.items;
+    try testing.expectEqual(@as(usize, 5), parsedAttrs.len);
+
+    try testing.expectEqual(ribModel.Origin.IGP, parsedAttrs[0].Origin.value);
+    
+    try testing.expectEqual(@as(u32, 200), parsedAttrs[1].LocalPref.value);
+    
+    try testing.expectEqual(@as(u8, 99), parsedAttrs[2].Unknown.value.typeCode);
+    try testing.expectEqualSlices(u8, &[_]u8{ 1, 2, 3, 4, 5 }, parsedAttrs[2].Unknown.value.value);
+    
+    try testing.expectEqual(@as(usize, 1), parsedAttrs[3].AsPath.value.segments.len);
+    try testing.expectEqual(ribModel.ASPathSegmentType.AS_Sequence, parsedAttrs[3].AsPath.value.segments[0].segType);
+    try testing.expectEqualSlices(u16, &[_]u16{ 100, 200 }, parsedAttrs[3].AsPath.value.segments[0].contents);
+    
+    try testing.expect(parsedAttrs[4].Nexthop.value.equals(ip.IpV4Address.parse("192.168.0.1") catch unreachable));
     
     // Ensure we read the entire buffer
     try testing.expectEqual(attributesBuffer.len, stream.getPos());

--- a/src/messaging/parsing/update.zig
+++ b/src/messaging/parsing/update.zig
@@ -386,7 +386,7 @@ test "readUpdateMessage()" {
         .allocator = testing.allocator,
         .reader = &reader.new_interface,
     };
-    const message = try updateReader.readUpdateMessage(@intCast(messageBuffer.len));
+    var message = try updateReader.readUpdateMessage(@intCast(messageBuffer.len));
     defer message.deinit();
 
     try testing.expectEqual(stream.getPos(), messageBuffer.len);

--- a/src/rib/adj_rib.zig
+++ b/src/rib/adj_rib.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const ip = @import("ip");
 
-const model = @import("../messaging/model.zig");
+const model = @import("./model.zig");
 
 const common = @import("./common.zig");
 

--- a/src/rib/adj_rib_manager.zig
+++ b/src/rib/adj_rib_manager.zig
@@ -4,7 +4,7 @@ const xev = @import("xev");
 
 const adjRib = @import("adj_rib.zig");
 const debounced = @import("../utils/debounced.zig");
-const model = @import("../messaging/model.zig");
+const model = @import("../rib/model.zig");
 const common = @import("common.zig");
 
 const Allocator = std.mem.Allocator;

--- a/src/rib/common.zig
+++ b/src/rib/common.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const ip = @import("ip");
 
-const model = @import("../messaging/model.zig");
+const model = @import("model.zig");
 
 const Allocator = std.mem.Allocator;
 

--- a/src/rib/main_rib.zig
+++ b/src/rib/main_rib.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const ip = @import("ip");
 
-const model = @import("../messaging/model.zig");
+const model = @import("./model.zig");
 
 const common = @import("./common.zig");
 

--- a/src/rib/main_rib.zig
+++ b/src/rib/main_rib.zig
@@ -97,8 +97,8 @@ const RibEntry = struct {
         }
 
         const path = self.paths.getPtr(advertiser) orelse return;
-
         path.deinit();
+
         _ = self.paths.remove(advertiser);
     }
 };

--- a/src/rib/main_rib_manager.zig
+++ b/src/rib/main_rib_manager.zig
@@ -4,7 +4,7 @@ const xev = @import("xev");
 
 const rib = @import("main_rib.zig");
 const debounced = @import("../utils/debounced.zig");
-const model = @import("../messaging/model.zig");
+const model = @import("../rib/model.zig");
 const common = @import("common.zig");
 
 const DoublyLinkedList = std.DoublyLinkedList;

--- a/src/rib/model.zig
+++ b/src/rib/model.zig
@@ -23,7 +23,7 @@ pub const ASPathSegment = struct {
     allocator: Allocator,
 
     segType: ASPathSegmentType,
-    contents: []const u16,
+    contents: []u16,
 
     pub fn deinit(self: Self) void {
         self.allocator.free(self.contents);

--- a/src/rib/model.zig
+++ b/src/rib/model.zig
@@ -311,7 +311,7 @@ pub const PathAttributes = struct {
     multiExitDiscriminator: ?MultiExitDiscriminatorAttr,
 
     // Optional, transitive
-    aggregator: ?Aggregator,
+    aggregator: ?AggregatorAttr,
 
     // TODO: track partial bit in recognised attrs
     // If a path with a recognized, transitive optional attribute is accepted

--- a/src/rib/model.zig
+++ b/src/rib/model.zig
@@ -1,0 +1,511 @@
+const std = @import("std");
+const ip = @import("ip");
+
+const Allocator = std.mem.Allocator;
+
+pub const Route = struct {
+    prefixLength: u8,
+    prefixData: [4]u8,
+
+    pub const default: Route = .{ .prefixLength = 0, .prefixData = [_]u8{0} ** 4 };
+};
+
+pub const Origin = enum(u8) {
+    IGP = 0,
+    EGP = 1,
+    INCOMPLETE = 2,
+};
+
+pub const ASPathSegmentType = enum(u8) { AS_Set = 1, AS_Sequence = 2 };
+pub const ASPathSegment = struct {
+    const Self = @This();
+
+    allocator: Allocator,
+
+    segType: ASPathSegmentType,
+    contents: []const u16,
+
+    pub fn deinit(self: Self) void {
+        self.allocator.free(self.contents);
+    }
+
+    pub fn clone(self: Self, allocator: std.mem.Allocator) !Self {
+        return Self{
+            .allocator = allocator,
+            .segType = self.segType,
+            .contents = try allocator.dupe(u16, self.contents),
+        };
+    }
+
+    pub inline fn equal(self: Self, other: Self) bool {
+        if (self.segType != other.segType) {
+            return false;
+        }
+
+        return std.mem.eql(u16, self.contents, other.contents);
+    }
+
+    pub fn hash(self: Self, hasher: anytype) void {
+        std.hash.autoHash(hasher, self.segType);
+        std.hash.autoHash(hasher, self.contents.len);
+        for (self.contents) |item| {
+            std.hash.autoHash(hasher, item);
+        }
+    }
+};
+
+pub const ASPath = struct {
+    // FIXME: Cloning logic should really be tested to ensure stuff lands on separate buffers
+    const Self = @This();
+
+    allocator: Allocator,
+    segments: []const ASPathSegment,
+
+    pub fn deinit(self: Self) void {
+        for (self.segments) |seg| {
+            seg.deinit();
+        }
+        self.allocator.free(self.segments);
+    }
+
+    pub fn clone(self: Self, allocator: std.mem.Allocator) !Self {
+        const newASPath = try allocator.alloc(ASPathSegment, self.segments.len);
+        errdefer allocator.free(newASPath);
+
+        for (0..newASPath.len) |i| {
+            newASPath[i] = try self.segments[i].clone(allocator);
+        }
+
+        return Self{ .allocator = allocator, .segments = newASPath };
+    }
+
+    pub inline fn equal(self: *const Self, other: *const Self) bool {
+        if (self.segments.len != other.segments.len) {
+            return false;
+        }
+
+        for (0..self.segments.len) |i| {
+            if (!self.segments[i].equal(other.segments[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    pub fn hash(self: Self, hasher: anytype) void {
+        std.hash.autoHash(hasher, self.segments.len);
+        for (self.segments) |seg| {
+            seg.hash(hasher);
+        }
+    }
+
+    pub fn createEmpty(allocator: Allocator) Self {
+        return Self{
+            .allocator = allocator,
+            .segments = allocator.dupe(ASPathSegment, &[_]ASPathSegment{}) catch {
+                std.debug.print("ERROR ALLOCATING EMPTY SLICE, WTF!!!!!", .{});
+                std.process.abort();
+            },
+        };
+    }
+
+    pub fn len(self: *const Self) usize {
+        var size: usize = 0;
+        for (self.segments) |segment| {
+            switch (segment.segType) {
+                .AS_Sequence => size += segment.contents.len,
+                .AS_Set => size += 1,
+            }
+        }
+        return size;
+    }
+
+    pub fn prependASN(self: *Self, asn: u16) !void {
+        // FIXME: Missing overflow protection (prevent segment length from
+        // going over 255)
+        if (self.segments.len == 0) {
+            const newSegments = try self.allocator.alloc(ASPathSegment, 1);
+
+            const contents = try self.allocator.alloc(u16, 1);
+            contents[0] = asn;
+            newSegments[0] = ASPathSegment{
+                .allocator = self.allocator,
+                .contents = contents,
+                .segType = .AS_Sequence,
+            };
+
+            self.allocator.free(self.segments);
+            self.segments = newSegments;
+            return;
+        }
+
+        switch (self.segments[0].segType) {
+            .AS_Sequence => {
+                var firstSegment = self.segments[0];
+                const newContents = try firstSegment.allocator.alloc(u16, firstSegment.contents.len + 1);
+                newContents[0] = asn;
+                std.mem.copyForwards(u16, newContents[1..], firstSegment.contents);
+                firstSegment.allocator.free(firstSegment.contents);
+                firstSegment.contents = newContents;
+                @constCast(self.segments)[0] = firstSegment;
+            },
+            .AS_Set => {
+                const newSegments = try self.allocator.alloc(ASPathSegment, self.segments.len + 1);
+                std.mem.copyForwards(ASPathSegment, newSegments[1..], self.segments);
+
+                const contents = try self.allocator.alloc(u16, 1);
+                contents[0] = asn;
+                newSegments[0] = ASPathSegment{
+                    .allocator = self.allocator,
+                    .contents = contents,
+                    .segType = .AS_Sequence,
+                };
+
+                self.allocator.free(self.segments);
+                self.segments = newSegments;
+            },
+        }
+    }
+
+    pub fn format(
+        self: *const Self,
+        writer: *std.Io.Writer,
+    ) std.Io.Writer.Error!void {
+        try writer.print("[", .{});
+        for (self.segments, 0..) |segment, segi| {
+            if (segment.segType == .AS_Sequence) {
+                try writer.print("seq{{", .{});
+            } else {
+                try writer.print("set{{", .{});
+            }
+            for (segment.contents, 0..) |asn, asni| {
+                try writer.print("{d}", .{asn});
+                if (asni < segment.contents.len-1) {
+                    try writer.print(", ", .{});
+                }
+            }
+            try writer.print("}}", .{});
+            if (segi < self.segments.len-1) {
+                try writer.print(", ", .{});
+            }
+        }
+        try writer.print("]", .{});
+    }
+};
+
+pub const Aggregator = struct {
+    const Self = @This();
+
+    as: u16,
+    address: ip.IpV4Address,
+
+    pub fn equal(self: *const Self, other: *const Self) bool {
+        return self.as == other.as and self.address.equals(other.address);
+    }
+
+    pub fn hash(self: Self, hasher: anytype) void {
+        std.hash.autoHash(hasher, self.as);
+        std.hash.autoHash(hasher, self.address);
+    }
+};
+
+pub const Unknown = struct {
+    allocator: Allocator,
+    typeCode: u8,
+    value: []u8,
+
+    pub fn deinit(self: *@This()) void {
+        self.allocator.free(self.value);
+    }
+};
+
+pub const ATTR_OPTIONAL_FLAG: u8 = 0x80;
+pub const ATTR_TRANSITIVE_FLAG: u8 = 0x40;
+pub const ATTR_PARTIAL_FLAG: u8 = 0x20;
+pub const ATTR_EXTENDED_LENGTH_FLAG: u8 = 0x10;
+pub fn Attribute(comptime AttrType: type) type {
+    return struct {
+        const Self = @This();
+
+        // Flags
+        flags: u8,
+
+        // Value
+        value: AttrType,
+
+        pub fn init(value: AttrType) Self {
+            return Self{
+                .flags = 0x00,
+                .value = value
+            };
+        }
+
+        pub fn isOptional(self: *const Self) bool {
+            return (self.flags & ATTR_OPTIONAL_FLAG) > 0;
+        }
+
+        pub fn isTransitive(self: *const Self) bool {
+            return (self.flags & ATTR_TRANSITIVE_FLAG) > 0;
+        }
+
+        pub fn isExtendedLength(self: *const Self) bool {
+            return (self.flags & ATTR_EXTENDED_LENGTH_FLAG) > 0;
+        }   
+
+        pub fn isPartial(self: *const Self) bool {
+            return (self.flags & ATTR_PARTIAL_FLAG) > 0;
+        }
+    };
+}
+
+fn areOptionalAttrsEqual(comptime Type: type, attr1: ?Attribute(Type), attr2: ?Attribute(Type)) bool {
+    if (attr1) |a1| {
+        if (attr2) |a2| {
+            if (@typeInfo(Type) == .@"struct" and @hasDecl(Type, "equal")) {
+                if (!a1.value.equal(&a2.value)) {
+                    return false;
+                }
+            } else {
+                if (a1.value != a2.value) {
+                    return false;
+                }
+            }
+        }
+    } else {
+        if (attr2 != null) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+pub const OriginAttr = Attribute(Origin);
+pub const AsPathAttr = Attribute(ASPath);
+pub const NexthopAttr = Attribute(ip.IpV4Address);
+pub const LocalPrefAttr = Attribute(u32);
+pub const AtomicAggregateAttr = Attribute(bool);
+pub const MultiExitDiscriminatorAttr = Attribute(u32);
+pub const AggregatorAttr = Attribute(Aggregator);
+pub const UnknownAttr = Attribute(Unknown);
+
+pub const PathAttributes = struct {
+    const Self = @This();
+
+    allocator: Allocator,
+
+    // Well known, Mandatory
+    origin: OriginAttr,
+    asPath: AsPathAttr,
+    nexthop: NexthopAttr,
+
+    // Well known
+    // Mandatory for internal peers or confeds
+    localPref: LocalPrefAttr,
+
+    // Well known, discretionary
+    atomicAggregate: ?AtomicAggregateAttr,
+
+    // Optional, non-transitive
+    multiExitDiscriminator: ?MultiExitDiscriminatorAttr,
+
+    // Optional, transitive
+    aggregator: ?Aggregator,
+
+    // TODO: track partial bit in recognised attrs
+    // If a path with a recognized, transitive optional attribute is accepted
+    // and passed along to other BGP peers and the Partial bit in the Attribute
+    // Flags octet is set to 1 by some previous AS, it MUST NOT be set back to
+    // 0 by the current AS.
+
+    // TODO: support unrecognised transitive attributes
+    // If a path with an unrecognized transitive optional attribute is accepted
+    // and passed to other BGP peers, then the unrecognized transitive optional
+    // attribute of that path MUST be passed, along with the path, to other BGP
+    // peers with the Partial bit in the Attribute Flags octet set to 1.
+
+    pub const empty: Self = .{
+        .allocator = undefined,
+        .origin = undefined,
+        .asPath = undefined,
+        .nexthop = undefined,
+        .localPref = .init(100),
+        .atomicAggregate = null,
+        .multiExitDiscriminator = null,
+        .aggregator = null,
+    };
+
+    pub fn deinit(self: Self) void {
+        self.asPath.value.deinit();
+    }
+
+    pub fn clone(self: Self, allocator: std.mem.Allocator) !Self {
+        var copy = Self{
+            .allocator = allocator,
+            .origin = self.origin,
+            .asPath = self.asPath,
+            .nexthop = self.nexthop,
+            .localPref = self.localPref,
+            .atomicAggregate = self.atomicAggregate,
+            .multiExitDiscriminator = self.multiExitDiscriminator,
+            .aggregator = self.aggregator,
+        };
+        copy.asPath.value = try self.asPath.value.clone(allocator);
+        return copy;
+    }
+
+    pub fn equal(self: *const Self, other: *const Self) bool {
+        if (self.origin.value != other.origin.value) return false;
+        if (!self.asPath.value.equal(&other.asPath.value)) return false;
+        if (!self.nexthop.value.equals(other.nexthop.value)) return false;
+        if (self.localPref.value != other.localPref.value) return false;
+
+        if (!areOptionalAttrsEqual(bool, self.atomicAggregate, other.atomicAggregate)) {
+            return false;
+        }
+
+        if (!areOptionalAttrsEqual(u32, self.multiExitDiscriminator, other.multiExitDiscriminator)) {
+            return false;
+        }
+
+        if (!areOptionalAttrsEqual(Aggregator, self.aggregator, other.aggregator)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    pub fn hash(self: Self, hasher: anytype) void {
+        std.hash.autoHash(hasher, self.origin.value);
+        self.asPath.value.hash(hasher);
+        std.hash.autoHash(hasher, self.nexthop.value);
+        std.hash.autoHash(hasher, self.localPref.value);
+        if (self.atomicAggregate) |v| {
+            std.hash.autoHash(hasher, v.value);
+        }
+        if (self.multiExitDiscriminator) |v| {
+            std.hash.autoHash(hasher, v.value);
+        }
+        if (self.aggregator) |agg| {
+            agg.value.hash(hasher);
+        }
+    }
+};
+
+test "PathAttributes hash and equal" {
+    const allocator = std.testing.allocator;
+
+    const as_path_seg = ASPathSegment{
+        .allocator = allocator,
+        .segType = .AS_Sequence,
+        .contents = try allocator.dupe(u16, &[_]u16{ 1, 2, 3 }),
+    };
+    defer as_path_seg.deinit();
+
+    const as_path = ASPath{
+        .allocator = allocator,
+        .segments = try allocator.dupe(ASPathSegment, &[_]ASPathSegment{try as_path_seg.clone(allocator)}),
+    };
+    defer as_path.deinit();
+
+    const attrs1 = PathAttributes{
+        .allocator = allocator,
+        .origin = .init(.IGP),
+        .asPath = .init(try as_path.clone(allocator)),
+        .nexthop = .init(ip.IpV4Address.parse("1.1.1.1") catch unreachable),
+        .localPref = .init(100),
+        .atomicAggregate = .init(false),
+        .multiExitDiscriminator = .init(0),
+        .aggregator = .init(.{
+            .as = 65001,
+            .address = ip.IpV4Address.parse("2.2.2.2") catch unreachable,
+        }),
+    };
+    defer attrs1.deinit();
+
+    const attrs2 = try attrs1.clone(allocator);
+    defer attrs2.deinit();
+
+    try std.testing.expect(attrs1.equal(&attrs2));
+
+    var hasher1 = std.hash.Wyhash.init(0);
+    attrs1.hash(&hasher1);
+    const h1 = hasher1.final();
+
+    var hasher2 = std.hash.Wyhash.init(0);
+    attrs2.hash(&hasher2);
+    const h2 = hasher2.final();
+
+    try std.testing.expectEqual(h1, h2);
+
+    // Test differences
+    var attrs3 = try attrs1.clone(allocator);
+    defer attrs3.deinit();
+    attrs3.localPref.value = 200;
+    try std.testing.expect(!attrs1.equal(&attrs3));
+
+    var hasher3 = std.hash.Wyhash.init(0);
+    attrs3.hash(&hasher3);
+    try std.testing.expect(h1 != hasher3.final());
+
+    // Test ASPath difference
+    var attrs4 = try attrs1.clone(allocator);
+    defer attrs4.deinit();
+    attrs4.asPath.value.deinit();
+    const new_seg = ASPathSegment{
+        .allocator = allocator,
+        .segType = .AS_Sequence,
+        .contents = try allocator.dupe(u16, &[_]u16{ 1, 2, 4 }),
+    };
+    attrs4.asPath.value = ASPath{
+        .allocator = allocator,
+        .segments = try allocator.dupe(ASPathSegment, &[_]ASPathSegment{new_seg}),
+    };
+    try std.testing.expect(!attrs1.equal(&attrs4));
+
+    var hasher4 = std.hash.Wyhash.init(0);
+    attrs4.hash(&hasher4);
+    try std.testing.expect(h1 != hasher4.final());
+}
+
+test "ASPath.prependASN" {
+    const allocator = std.testing.allocator;
+
+    // 1. Test empty ASPath
+    var as_path = ASPath.createEmpty(allocator);
+    defer as_path.deinit();
+
+    try as_path.prependASN(100);
+    try std.testing.expectEqual(@as(usize, 1), as_path.segments.len);
+    try std.testing.expectEqual(ASPathSegmentType.AS_Sequence, as_path.segments[0].segType);
+    try std.testing.expectEqual(@as(usize, 1), as_path.segments[0].contents.len);
+    try std.testing.expectEqual(@as(u16, 100), as_path.segments[0].contents[0]);
+
+    // 2. Test prepending to existing AS_Sequence
+    try as_path.prependASN(200);
+    try std.testing.expectEqual(@as(usize, 1), as_path.segments.len);
+    try std.testing.expectEqual(ASPathSegmentType.AS_Sequence, as_path.segments[0].segType);
+    try std.testing.expectEqual(@as(usize, 2), as_path.segments[0].contents.len);
+    try std.testing.expectEqual(@as(u16, 200), as_path.segments[0].contents[0]);
+    try std.testing.expectEqual(@as(u16, 100), as_path.segments[0].contents[1]);
+
+    // 3. Test prepending to AS_Set (should create new AS_Sequence)
+    var as_set_path = ASPath{
+        .allocator = allocator,
+        .segments = try allocator.alloc(ASPathSegment, 1),
+    };
+    @constCast(as_set_path.segments)[0] = ASPathSegment{
+        .allocator = allocator,
+        .segType = .AS_Set,
+        .contents = try allocator.dupe(u16, &[_]u16{ 300, 400 }),
+    };
+    defer as_set_path.deinit();
+
+    try as_set_path.prependASN(500);
+    try std.testing.expectEqual(@as(usize, 2), as_set_path.segments.len);
+    try std.testing.expectEqual(ASPathSegmentType.AS_Sequence, as_set_path.segments[0].segType);
+    try std.testing.expectEqual(@as(usize, 1), as_set_path.segments[0].contents.len);
+    try std.testing.expectEqual(@as(u16, 500), as_set_path.segments[0].contents[0]);
+    try std.testing.expectEqual(ASPathSegmentType.AS_Set, as_set_path.segments[1].segType);
+}

--- a/src/rib/model.zig
+++ b/src/rib/model.zig
@@ -23,7 +23,7 @@ pub const ASPathSegment = struct {
     allocator: Allocator,
 
     segType: ASPathSegmentType,
-    contents: []u16,
+    contents: []const u16,
 
     pub fn deinit(self: Self) void {
         self.allocator.free(self.contents);

--- a/src/rib/rib_thread.zig
+++ b/src/rib/rib_thread.zig
@@ -3,8 +3,10 @@ const zul = @import("zul");
 const ip = @import("ip");
 const adjRibManager = @import("adj_rib_manager.zig");
 const mainRibManager = @import("main_rib_manager.zig");
-const model = @import("../messaging/model.zig");
+const model = @import("model.zig");
 const common = @import("common.zig");
+const utils = @import("utils.zig");
+const messageModel = @import("../messaging/model.zig");
 
 const Allocator = std.mem.Allocator;
 
@@ -299,7 +301,10 @@ pub const SyncTask = struct {
                     .allocator = ctx.allocator,
                     .withdrawnRoutes = &[_]model.Route{deletedRoute},
                     .advertisedRoutes = &[_]model.Route{},
-                    .pathAttributes = null,
+                    .pathAttributes = .{
+                        .alloc = ctx.allocator,
+                        .list = .empty,
+                    },
                 } });
             }
             var aggIter = aggregatedRoutes.groups.iterator();
@@ -313,12 +318,14 @@ pub const SyncTask = struct {
 
                 for (group.value_ptr.items) |route| {
                     std.log.info("Sending update", .{});
-                    try peer.session.sendMessage(.{ .UPDATE = .{ 
+                    const msg: messageModel.BgpMessage = .{ .UPDATE = .{ 
                         .allocator = ctx.allocator, 
                         .withdrawnRoutes = &[_]model.Route{}, 
                         .advertisedRoutes = &[_]model.Route{route},
-                        .pathAttributes = attrs 
-                    } });
+                        .pathAttributes = try utils.convertUnifiedStructToAttributeList(ctx.allocator, peerType, attrs),
+                    } };
+                    defer msg.deinit();
+                    try peer.session.sendMessage(msg);
                 }
             }
         }

--- a/src/rib/rib_thread.zig
+++ b/src/rib/rib_thread.zig
@@ -310,6 +310,7 @@ pub const SyncTask = struct {
             var aggIter = aggregatedRoutes.groups.iterator();
             while (aggIter.next()) |group| {
                 var attrs = try group.key_ptr.clone(ctx.allocator);
+                defer attrs.deinit();
 
                 if (peerType == .External) {
                     attrs.nexthop.value = sessionsAddresses.localAddress;
@@ -318,12 +319,12 @@ pub const SyncTask = struct {
 
                 for (group.value_ptr.items) |route| {
                     std.log.info("Sending update", .{});
-                    const msg: messageModel.BgpMessage = .{ .UPDATE = .{ 
-                        .allocator = ctx.allocator, 
-                        .withdrawnRoutes = &[_]model.Route{}, 
-                        .advertisedRoutes = &[_]model.Route{route},
-                        .pathAttributes = try utils.convertUnifiedStructToAttributeList(ctx.allocator, peerType, attrs),
-                    } };
+                    var msg: messageModel.BgpMessage = .{ .UPDATE = try .init(
+                        ctx.allocator, 
+                        &[_]model.Route{}, 
+                        &[_]model.Route{route},
+                        try utils.convertUnifiedStructToAttributeList(ctx.allocator, peerType, attrs),
+                    ) };
                     defer msg.deinit();
                     try peer.session.sendMessage(msg);
                 }

--- a/src/rib/utils.zig
+++ b/src/rib/utils.zig
@@ -1,0 +1,100 @@
+const std = @import("std");
+const ribModel = @import("../rib/model.zig");
+const messageModel = @import("../messaging/model.zig");
+const session = @import("../sessions/session.zig");
+
+const Allocator = std.mem.Allocator;
+
+pub fn convertAttributeListToUnifiedStruct(allocator: Allocator, peerType: session.Session.PeerType, attrList: messageModel.AttributeList) !?ribModel.PathAttributes {
+    if (attrList.list.items.len == 0) {
+        return null;
+    }
+    var attributes: ribModel.PathAttributes = .empty;
+    attributes.allocator = allocator;
+
+    attributes.localPref = .{
+        .flags = 0,
+        .value = 100
+    };
+
+    var originRead: bool = false;
+    var asPathRead: bool = false;
+    var nextHopRead: bool = false;
+
+    for (attrList.list.items) |attr| {
+        switch (attr) {
+            .Origin => |origin| {
+                attributes.origin = origin;
+                originRead = true;
+            },
+            .AsPath => |asPath| {
+                attributes.asPath = asPath;
+                attributes.asPath.value = try asPath.value.clone(allocator);
+                asPathRead = true;
+            },
+            .Nexthop => |nexthop| {
+                attributes.nexthop = nexthop;
+                nextHopRead = true;
+            },
+            .MultiExitDiscriminator => |med| {
+                attributes.multiExitDiscriminator = med;
+            },
+            .LocalPref => |lpref| {
+                if (peerType == .Internal) {
+                    attributes.localPref = lpref;
+                }
+            },
+            .AtomicAggregate => |aAgg| {
+                attributes.atomicAggregate = aAgg;
+            },
+            .Aggregator => |agg| {
+                attributes.aggregator = agg;
+            },
+            .Unknown => |uk| {
+                std.log.info("Unknown parameter (type={})", .{uk.value.typeCode});
+            }
+        }
+    }
+    
+    if (!originRead) {
+        return error.MissingOriginAttribute;
+    }
+    if (!asPathRead) {
+        return error.MissingASPathAttribute;
+    }
+    if (!nextHopRead) {
+        return error.MissingNexthopAttribute;
+    }
+
+    return attributes;
+}
+
+pub fn convertUnifiedStructToAttributeList(allocator: Allocator, peerType: session.Session.PeerType, attrs: ribModel.PathAttributes) !messageModel.AttributeList {
+    var attributes: messageModel.AttributeList = .{
+        .alloc = allocator,
+        .list = try .initCapacity(allocator, 3),
+    };
+    errdefer attributes.deinit();
+
+    try attributes.list.append(allocator, .{ .Origin = attrs.origin });
+    {
+        var asPath = attrs.asPath;
+        asPath.value = try attrs.asPath.value.clone(allocator);
+        try attributes.list.append(allocator, .{ .AsPath = asPath });
+    }
+    try attributes.list.append(allocator, .{ .Nexthop = attrs.nexthop });
+    if (attrs.multiExitDiscriminator) |med| {
+        try attributes.list.append(allocator, .{ .MultiExitDiscriminator = med });
+    }
+    if (peerType == .Internal) {
+        try attributes.list.append(allocator, .{ .LocalPref = attrs.localPref });
+    }
+    if (attrs.atomicAggregate) |aAgg| {
+        try attributes.list.append(allocator, .{ .AtomicAggregate = aAgg });
+    }
+    if (attrs.aggregator) |agg| {
+        try attributes.list.append(allocator, .{ .Aggregator = agg });
+    }
+
+    return attributes;
+}

--- a/src/rib/utils.zig
+++ b/src/rib/utils.zig
@@ -98,3 +98,67 @@ pub fn convertUnifiedStructToAttributeList(allocator: Allocator, peerType: sessi
 
     return attributes;
 }
+
+test "symmetry between attribute conversions obj -> list -> obj" {
+    const testing = std.testing;
+    const ip = @import("ip");
+    
+    // Create a robust initial structure
+    const as_path_seg = ribModel.ASPathSegment{
+        .allocator = testing.allocator,
+        .segType = .AS_Sequence,
+        .contents = try testing.allocator.dupe(u16, &[_]u16{ 1, 2, 3 }),
+    };
+    defer as_path_seg.deinit();
+
+    const as_path = ribModel.ASPath{
+        .allocator = testing.allocator,
+        .segments = try testing.allocator.dupe(ribModel.ASPathSegment, &[_]ribModel.ASPathSegment{try as_path_seg.clone(testing.allocator)}),
+    };
+
+    const attrs1 = ribModel.PathAttributes{
+        .allocator = testing.allocator,
+        .origin = .init(.IGP),
+        .asPath = .init(as_path),
+        .nexthop = .init(try ip.IpV4Address.parse("1.1.1.1")),
+        .localPref = .init(200),
+        .atomicAggregate = .init(false),
+        .multiExitDiscriminator = .init(10),
+        .aggregator = .init(.{
+            .as = 65001,
+            .address = try ip.IpV4Address.parse("2.2.2.2"),
+        }),
+    };
+    defer attrs1.deinit();
+
+    // Test Internal peer type encoding/decoding symmetry
+    {
+        var attrList = try convertUnifiedStructToAttributeList(testing.allocator, .Internal, attrs1);
+        defer attrList.deinit();
+
+        const attrs2_opt = try convertAttributeListToUnifiedStruct(testing.allocator, .Internal, attrList);
+        try testing.expect(attrs2_opt != null);
+        var attrs2 = attrs2_opt.?;
+        defer attrs2.deinit();
+
+        try testing.expect(attrs1.equal(&attrs2));
+    }
+
+    // Test External peer type encoding/decoding symmetry
+    {
+        var attrList = try convertUnifiedStructToAttributeList(testing.allocator, .External, attrs1);
+        defer attrList.deinit();
+
+        const attrs3_opt = try convertAttributeListToUnifiedStruct(testing.allocator, .External, attrList);
+        try testing.expect(attrs3_opt != null);
+        var attrs3 = attrs3_opt.?;
+        defer attrs3.deinit();
+
+        // LocalPref is forced to 100 on reading External attributes
+        var expected_attrs3 = try attrs1.clone(testing.allocator);
+        defer expected_attrs3.deinit();
+        expected_attrs3.localPref.value = 100;
+
+        try testing.expect(expected_attrs3.equal(&attrs3));
+    }
+}

--- a/src/sessions/handlers/established.zig
+++ b/src/sessions/handlers/established.zig
@@ -97,15 +97,6 @@ fn handleKeepAliveReceived(session: *Session) !PostHandlerAction {
 fn handleUpdateReceived(session: *Session, msg: model.UpdateMessage) !PostHandlerAction {
     try session.holdTimer.reschedule();
 
-    // Ignore external peers localPref by restting it to the default value
-    if (session.info.?.peerType == .External) {
-        if (msg.pathAttributes) |*a| {
-            var attrs = @constCast(a);
-            attrs.localPref.flags = 0;
-            attrs.localPref.value = 200; // Default value
-        }
-    }
-
     try session.processUpdateMsg(msg);
 
     return .keep;

--- a/src/sessions/session.zig
+++ b/src/sessions/session.zig
@@ -64,13 +64,13 @@ pub const Event = union(enum) {
     UpdateReceived: messageModel.UpdateMessage,
     NotificationReceived: messageModel.NotificationMessage,
 
-    pub fn deinit(self: @This()) void {
-        switch (self) {
+    pub fn deinit(self: *@This()) void {
+        switch (@constCast(self).*) {
             .OpenReceived => { },
-            .UpdateReceived => |msg| {
+            .UpdateReceived => |*msg| {
                 msg.deinit();
             },
-            .NotificationReceived => |msg| {
+            .NotificationReceived => |*msg| {
                 msg.deinit();
             },
             .OpenCollisionDump => { },
@@ -425,7 +425,8 @@ pub const Session = struct {
     }
 
     pub fn handleEvent(self: *Self, event: Event) void {
-        defer event.deinit();
+        // TODO: find way to not have to do this...
+        defer @constCast(&event).deinit();
 
         self.mutex.lock();
         defer self.mutex.unlock();

--- a/src/sessions/session.zig
+++ b/src/sessions/session.zig
@@ -14,6 +14,9 @@ const activeHandler = @import("handlers/active.zig");
 const openSentHandler = @import("handlers/open_sent.zig");
 const openConfirmHandler = @import("handlers/open_confirm.zig");
 const establishedHandler = @import("handlers/established.zig");
+const ribModel = @import("../rib/model.zig");
+
+const ribUtils = @import("../rib/utils.zig");
 
 const ribManager = @import("../rib/main_rib_manager.zig");
 const adjRibManager = @import("../rib/adj_rib_manager.zig");
@@ -443,12 +446,14 @@ pub const Session = struct {
     }
 
     pub fn processUpdateMsg(self: *Self, msg: messageModel.UpdateMessage) !void {
+        const pathAttributes: ?ribModel.PathAttributes = try ribUtils.convertAttributeListToUnifiedStruct(self.allocator, self.info.?.peerType, msg.pathAttributes);
+
         for (msg.withdrawnRoutes) |route| {
             self.adjRibInManager.?.removePath(route);
         }
 
         for (msg.advertisedRoutes) |route| {
-            try self.adjRibInManager.?.setPath(route, msg.pathAttributes.?);
+            try self.adjRibInManager.?.setPath(route, pathAttributes.?);
         }
     }
 };

--- a/src/sessions/session.zig
+++ b/src/sessions/session.zig
@@ -63,6 +63,20 @@ pub const Event = union(enum) {
     OpenCollisionDump: CollisionContext,
     UpdateReceived: messageModel.UpdateMessage,
     NotificationReceived: messageModel.NotificationMessage,
+
+    pub fn deinit(self: @This()) void {
+        switch (self) {
+            .OpenReceived => { },
+            .UpdateReceived => |msg| {
+                msg.deinit();
+            },
+            .NotificationReceived => |msg| {
+                msg.deinit();
+            },
+            .OpenCollisionDump => { },
+            else => {},
+        }
+    }
 };
 
 pub const PostHandlerAction = union(enum) {
@@ -411,6 +425,8 @@ pub const Session = struct {
     }
 
     pub fn handleEvent(self: *Self, event: Event) void {
+        defer event.deinit();
+
         self.mutex.lock();
         defer self.mutex.unlock();
 
@@ -425,18 +441,6 @@ pub const Session = struct {
         switch (nextAction) {
             .Transition => |nextState| self.switchState(nextState),
             .Keep => {},
-        }
-
-        switch (@constCast(&event).*) {
-            .OpenReceived => { },
-            .UpdateReceived => |*msg| {
-                msg.deinit();
-            },
-            .NotificationReceived => |*msg| {
-                msg.deinit();
-            },
-            .OpenCollisionDump => { },
-            else => {},
         }
     }
 

--- a/src/sessions/session.zig
+++ b/src/sessions/session.zig
@@ -65,7 +65,7 @@ pub const Event = union(enum) {
     NotificationReceived: messageModel.NotificationMessage,
 
     pub fn deinit(self: *@This()) void {
-        switch (@constCast(self).*) {
+        switch (self.*) {
             .OpenReceived => { },
             .UpdateReceived => |*msg| {
                 msg.deinit();

--- a/src/sessions/session.zig
+++ b/src/sessions/session.zig
@@ -288,9 +288,7 @@ pub const Session = struct {
         var connectionWriter = connection.writer(&writeBuffer);
 
         
-        try self.messageEncoder.writeMessage(.{
-            .peerType = if (self.info != null) self.info.?.peerType else null
-        }, msg, &connectionWriter.interface);
+        try self.messageEncoder.writeMessage(msg, &connectionWriter.interface);
 
         std.log.debug("Sent message", .{});
 

--- a/src/sessions/session.zig
+++ b/src/sessions/session.zig
@@ -66,14 +66,12 @@ pub const Event = union(enum) {
 
     pub fn deinit(self: *@This()) void {
         switch (self.*) {
-            .OpenReceived => { },
             .UpdateReceived => |*msg| {
                 msg.deinit();
             },
             .NotificationReceived => |*msg| {
                 msg.deinit();
             },
-            .OpenCollisionDump => { },
             else => {},
         }
     }

--- a/src/sessions/session.zig
+++ b/src/sessions/session.zig
@@ -424,29 +424,29 @@ pub const Session = struct {
 
         switch (nextAction) {
             .Transition => |nextState| self.switchState(nextState),
-            .Keep => return,
+            .Keep => {},
         }
 
-
-        switch (event) {
-            .OpenReceived => |msg| {
-                self.messageReader.deInitMessage(.{ .OPEN = msg });
+        switch (@constCast(&event).*) {
+            .OpenReceived => { },
+            .UpdateReceived => |*msg| {
+                msg.deinit();
             },
-            .UpdateReceived => |msg| {
-                self.messageReader.deInitMessage(.{ .UPDATE = msg });
+            .NotificationReceived => |*msg| {
+                msg.deinit();
             },
-            .NotificationReceived => |msg| {
-                self.messageReader.deInitMessage(.{ .NOTIFICATION = msg });
-            },
-            .OpenCollisionDump => |ctx| {
-                self.messageReader.deInitMessage(.{ .OPEN = ctx.openMsg });
-            },
+            .OpenCollisionDump => { },
             else => {},
         }
     }
 
     pub fn processUpdateMsg(self: *Self, msg: messageModel.UpdateMessage) !void {
         const pathAttributes: ?ribModel.PathAttributes = try ribUtils.convertAttributeListToUnifiedStruct(self.allocator, self.info.?.peerType, msg.pathAttributes);
+        defer {
+            if (pathAttributes) |attrs| {
+                attrs.deinit();
+            }
+        }
 
         for (msg.withdrawnRoutes) |route| {
             self.adjRibInManager.?.removePath(route);


### PR DESCRIPTION
Converted the attributes in the Update message struct to a list of attributes.
This helps dumb down the parsing and encoding of messages. There are utility functions that convert between the struct and the list. This shifts the responsibility of validating and putting the messages together onto other places in the code base, which I find more ergonomic.

This led me to also add parsing and encoding of the rest of the attributes + a bunch of bug fixes.